### PR TITLE
test: add Playwright visual regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ build/
 coverage/
 .nyc_output/
 
+# Visual regression tests — screenshots are ephemeral (regenerate with npm run test:visual:baseline)
+e2e/screenshots/
+
 # Debug
 debug/
 .debug/

--- a/.opencode/plans/2026-03-27-carousel-gallery-effects.md
+++ b/.opencode/plans/2026-03-27-carousel-gallery-effects.md
@@ -1,0 +1,37 @@
+# Phase 17: SimpleCarousel & Gallery Effects Restoration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restore hand-crafted per-project gallery carousel effects on the homepage — replacing static single-image sections with auto-advancing CSS-only carousels.
+
+**Architecture:** A `SimpleCarousel` component (CSS transitions only) renders stacked slides with configurable animation types and auto-advance timing. Each project's `ProjectDetail` gains a `gallery` config. The homepage `WorkGalleryItem` cycles through multiple gallery images. Project detail pages keep `GalleryGrid` unchanged.
+
+**Tech Stack:** React 18, TypeScript, CSS transitions, Next.js `<Image>`, existing `animationConfigs.ts`
+
+**Branch:** `feature/phase-17-carousel-gallery-effects` (from `main`)
+
+---
+
+## Tasks
+
+### Task 1: GalleryConfig type
+- Create: `src/types/gallery.ts`
+- Modify: `src/config/projects.ts` — add `gallery?` field to `ProjectDetail`
+- Test: `src/__tests__/types/gallery.test.ts`
+
+### Task 2: Per-project gallery configs
+- Modify: `src/config/projects.ts` — add `gallery` to all 10 projects
+
+### Task 3: SimpleCarousel component
+- Create: `src/components/ui/SimpleCarousel.tsx`
+- Test: `src/__tests__/components/ui/SimpleCarousel.test.tsx`
+
+### Task 4: Barrel export
+- Modify: `src/components/ui/index.ts`
+
+### Task 5: Homepage integration
+- Modify: `src/components/home/WorkGalleryItem.tsx`
+- Modify: `src/app/page.tsx`
+- Modify: `src/__tests__/components/home/WorkGalleryItem.test.tsx`
+
+### Task 6: Build verification + PR

--- a/.opencode/plans/2026-03-30-production-readiness-roadmap.md
+++ b/.opencode/plans/2026-03-30-production-readiness-roadmap.md
@@ -1,0 +1,184 @@
+# HAUS Creative — Production Readiness Roadmap
+
+> **Created:** 2026-03-30
+> **Last updated:** 2026-03-30
+> **Status:** Active — Phase 21 in progress
+
+---
+
+## Progress to Date
+
+### Pre-production push (Nov 2025 – Dec 2025)
+
+| PR | What |
+|----|------|
+| #1–#3 | Gallery display improvements, add remaining galleries |
+| #6–#12 | Dark theme redesign, stabilisation, accessibility, feature flags |
+| #13–#16 | Component cleanup, header layout, gallery enhancements |
+| #17 | Design alignment |
+| #18 | Mobile scroll jitter fix |
+
+### Production readiness push (Mar 2026)
+
+| Phase | PR | Branch | What |
+|-------|----|--------|------|
+| 0 | — | — | Agentic infrastructure (skills, AGENTS.md, subagents) |
+| 1 | #19 | `feature/phase-1-critical-fixes` | Security headers, contact email, social handles, config corrections |
+| 2 | #20 | `feature/phase-2-seo-marketing` | SEO metadata, sitemap, robots.txt, JSON-LD structured data |
+| 3 | #21 | `feature/phase-3-testing-quality` | Test suite from ~11% to 77% coverage |
+| 4 | #22 | `feature/phase-4-ci-cd` | GitHub Actions CI (type-check, lint, test, build, Lighthouse) |
+| 5 | #23 | `feature/phase-5-cleanup-polish` | Unused deps, .env.example, v1.0.0 |
+| 6 | #24 | `fix/phase-6-audit-a11y` | aria-hidden-focus a11y fix |
+| 7–8 | #25 | `feature/phase-7-asset-optimisation` | PNG→WebP conversion, 9 named Figma projects |
+| 11 | #26 | `feature/phase-11-asset-gap-closure` | 124 Figma asset downloads, Bride Story project |
+| 13 | #27 | `feature/phase-13-visual-alignment` | Figma design token alignment |
+| 14 | #28 | `feature/phase-14-visual-audit` | Full visual audit — all pages aligned to Figma |
+| 15 | #29 | `feature/phase-15-project-data-gaps` | MC Arabia credits/logo, YSL title, 21 missing gallery images |
+| 16 | #30 | `feature/phase-16-gallery-layouts-and-cleanup` | GalleryGrid per-project layouts matching Figma |
+| 17 | #31 | `feature/phase-17-carousel-gallery-effects` | Homepage SimpleCarousel with per-project animation configs |
+| 18 | #32 | `fix/mobile-polish` | dvh viewport, touch swipe, iOS scroll lock, responsive spacing |
+| 19 | #33 | `perf/video-optimisation` | LazyVideo component, poster images, preload attributes |
+| 20 | #34 | `test/coverage-boost` | Coverage 70% → 93%+ (266 tests, 32 suites) |
+| 21 | #35 | `test/playwright-visual` | Playwright visual regression testing (open) |
+
+### Current state
+
+- **Live:** https://haus-creative.vercel.app (auto-deploys from `main`)
+- **Quality gates:** type-check ✓, lint ✓, 266 unit tests ✓, 93%+ coverage, CI pipeline
+- **Assets:** All WebP, 4 MP4 videos, 10 projects with full gallery data
+- **Accessibility:** Skip link, landmarks, ARIA, focus-visible, reduced-motion
+- **SEO:** Sitemap, robots.txt, JSON-LD, canonical URLs, per-page metadata
+
+---
+
+## Remaining Phases
+
+### Phase 22: Code Cleanup & Dead Code Removal
+**Priority:** Medium | **Branch:** `refactor/code-cleanup` | **Effort:** Small
+
+Remove dead code identified in the audit. No functional changes.
+
+- [ ] Remove `VideoHero` component (superseded by `IntroHero` + `MediaRenderer`, never imported)
+- [ ] Remove dead `assetPath.ts` utilities (`getAssetPath`, `getGalleryAssets`, `titleToFileName` — only referenced in tests)
+- [ ] Remove `LazyVideo` component if confirmed unused (exported but never imported)
+- [ ] Remove unused font families from `tailwind.config.js` (`times`, `diatype`, `monument-grotesk-mono` — CSS vars never defined)
+- [ ] Remove unused content path `./src/pages/**/*` from `tailwind.config.js`
+- [ ] Remove placeholder fallback `"/images/placeholder.jpg"` from `createMediaSource()` in `site.ts` (file doesn't exist)
+- [ ] Centralise `NEXT_PUBLIC_SITE_URL` pattern (repeated in 4 files → move to `siteConfig`)
+- [ ] Unify external link pattern (`<a>` vs `<Link>` for external URLs)
+- [ ] Update `<html lang="en">` → `<html lang="en-GB">` (British English site)
+- [ ] Update affected tests
+
+### Phase 23: Production Meta & Icons
+**Priority:** Medium | **Branch:** `feat/production-meta` | **Effort:** Small
+
+Complete the production metadata — OG image, favicons, manifest.
+
+- [ ] Design/source OG image (1200×630) — may need designer input
+- [ ] Add `apple-touch-icon.png` (180×180) to `public/`
+- [ ] Add `site.webmanifest` with name, theme colour, icons
+- [ ] Add `openGraph.images` and `twitter.images` to root layout metadata
+- [ ] Export explicit `viewport` with `themeColor` from layout
+- [ ] Verify social share previews with OpenGraph debugger
+
+### Phase 24: Security Hardening (CSP)
+**Priority:** Medium | **Branch:** `fix/csp-header` | **Effort:** Small
+
+Add Content-Security-Policy header. Static site with no third-party scripts makes this straightforward.
+
+- [ ] Define CSP directives (self-only for scripts/styles, data: for images, media-src for videos)
+- [ ] Add CSP header to `next.config.js` security headers
+- [ ] Test that all pages render correctly with CSP enabled
+- [ ] Verify no console CSP violations
+
+### Phase 25: CI Pipeline Improvements
+**Priority:** Low | **Branch:** `ci/pipeline-improvements` | **Effort:** Small
+
+Strengthen the CI pipeline based on audit findings.
+
+- [ ] Add `npm run format:check` step (Prettier)
+- [ ] Add `npm audit --audit-level=moderate` step
+- [ ] Upload coverage report as GitHub Actions artifact
+- [ ] Add mobile Lighthouse preset alongside desktop
+- [ ] Increase Lighthouse `numberOfRuns` to 3 for stability
+- [ ] Consider adding visual regression test step (requires Playwright in CI)
+
+### Phase 26: SEO Enhancements
+**Priority:** Low | **Branch:** `feat/seo-enhancements` | **Effort:** Small
+
+Improve structured data and SEO signals.
+
+- [ ] Add `BreadcrumbList` JSON-LD to project detail pages
+- [ ] Add `CreativeWork` or `ImageGallery` schema to project pages
+- [ ] Enrich Organisation schema with `logo`, `address` (if available)
+- [ ] Verify all structured data with Google Rich Results Test
+
+### Phase 27: Accessibility Polish
+**Priority:** Low | **Branch:** `fix/a11y-polish` | **Effort:** Small
+
+Address remaining accessibility gaps.
+
+- [ ] Add `aria-label` to decorative video containers (describe visual content)
+- [ ] Return focus to menu toggle on mobile menu close
+- [ ] Consider `<track kind="descriptions">` for videos (WCAG AAA, optional)
+- [ ] Audit with axe-core or Lighthouse accessibility
+
+### Phase 28: Font Loading Strategy
+**Priority:** Low | **Branch:** `feat/font-loading` | **Effort:** Small
+
+Resolve the Inter font ambiguity — either load it properly or remove references.
+
+- [ ] Decide: load Inter via `next/font/google` or remove all Inter references
+- [ ] If loading: add to `layout.tsx`, apply via CSS variable, update Tailwind config
+- [ ] If removing: strip from `tailwind.config.js`, `globals.css`, `fonts.ts`
+- [ ] Verify no FOUT (Flash of Unstyled Text)
+
+### Phase 29: Performance Optimisation
+**Priority:** Low | **Branch:** `perf/optimisations` | **Effort:** Small
+
+Minor performance wins identified in the audit.
+
+- [ ] Add `priority` prop to first `WorkGalleryItem` (above-fold on scroll/link navigation)
+- [ ] Consider WebM video alternatives for Chrome/Firefox (smaller files)
+- [ ] Review `MediaRenderer` raw `<img>` path — convert to `<Image>` or remove
+
+---
+
+## Blocked / Needs Designer Input
+
+These items cannot proceed without assets or decisions from the designer:
+
+| Item | Dependency |
+|------|-----------|
+| OG image (1200×630) | Needs design/branding asset |
+| apple-touch-icon (180×180) | Needs design/branding asset |
+| HD gallery assets | User will provide and reorder later |
+| Non-MC Arabia project credits | Real photographer/stylist credits needed |
+| Placeholder subtitles | Real copy needed for project descriptions |
+| Phone frame fidelity (Vivara, Life, SK) | Confirm if current mockups match Figma intent |
+
+## Domain & Deployment
+
+| Item | Status |
+|------|--------|
+| Vercel auto-deploy from `main` | ✅ Working |
+| `studiohauscreative.com` custom domain | ⬜ Pending — connect on Vercel |
+| `NEXT_PUBLIC_SITE_URL` env var | ⬜ Update to `https://studiohauscreative.com` when domain is live |
+| SSL certificate | Automatic via Vercel once domain is connected |
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-03-23 | Phases branch from `main` independently | PRs can merge in any order |
+| 2026-03-24 | WebP q=90, pngScale: 2 for Figma exports | Balance quality vs file size for luxury portfolio |
+| 2026-03-26 | Keep project title overlays on homepage | UX enhancement not in Figma — user confirmed |
+| 2026-03-26 | Keep Ouronyx video hero as homepage landing | Not the MC Arabia hero from Figma |
+| 2026-03-26 | Keep GalleryGrid on detail pages | User chose scrollable grid over carousel for detail |
+| 2026-03-26 | No coloured backgrounds on YSL | Figma has no colorFrame for YSL |
+| 2026-03-27 | CSS-only animations, no Framer Motion | Project convention, existing carousel uses CSS transitions |
+| 2026-03-27 | Gallery effects are hand-crafted per-project | Each project has deliberate animation/timing choices |
+| 2026-03-30 | Hash-based screenshot comparison | Pure-Python pixel diffing too slow for 106MB+ screenshots |
+| 2026-03-30 | Baselines gitignored, not committed | 106MB too heavy for git; regenerate with npm script |

--- a/e2e/visual_test.py
+++ b/e2e/visual_test.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+Visual regression test script for HAUS Creative portfolio.
+
+Captures screenshots of all pages at desktop (1920x1080) and mobile (375x812)
+viewports, then compares against baselines using file-hash and dimension checks.
+
+Usage:
+    # Capture baselines (first run or after intentional visual changes):
+    python3 e2e/visual_test.py --baseline
+
+    # Compare current against baselines:
+    python3 e2e/visual_test.py
+
+    # With server management (recommended):
+    python3 .agents/skills/webapp-testing/scripts/with_server.py \
+        --server "npm start" --port 3000 -- python3 e2e/visual_test.py
+
+    # Update a single baseline:
+    python3 e2e/visual_test.py --baseline --page /about
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+from playwright.sync_api import sync_playwright
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:3000")
+
+VIEWPORTS = {
+    "desktop": {"width": 1920, "height": 1080},
+    "mobile": {"width": 375, "height": 812},
+}
+
+# All routes to test — matches the 14 known routes
+PAGES = [
+    "/",
+    "/about",
+    "/contact",
+    "/work",
+    "/work/ouronyx",
+    "/work/marie-claire-arabia",
+    "/work/ysl",
+    "/work/wao-cosmo",
+    "/work/vivara",
+    "/work/bucherer-summer",
+    "/work/sk",
+    "/work/bfj",
+    "/work/life",
+    "/work/bride-story",
+]
+
+# Directories
+SCRIPT_DIR = Path(__file__).resolve().parent
+BASELINE_DIR = SCRIPT_DIR / "screenshots" / "baseline"
+CURRENT_DIR = SCRIPT_DIR / "screenshots" / "current"
+
+
+# ---------------------------------------------------------------------------
+# Comparison utilities
+# ---------------------------------------------------------------------------
+
+
+def _png_dimensions(filepath: Path) -> tuple:
+    """Read width and height from a PNG file's IHDR chunk (fast, no decoding)."""
+    with open(filepath, "rb") as f:
+        sig = f.read(8)
+        if sig != b"\x89PNG\r\n\x1a\n":
+            raise ValueError(f"Not a valid PNG: {filepath}")
+        f.read(4)  # chunk length
+        chunk_type = f.read(4)
+        if chunk_type != b"IHDR":
+            raise ValueError(f"First chunk is not IHDR: {filepath}")
+        ihdr = f.read(8)
+        width = struct.unpack(">I", ihdr[0:4])[0]
+        height = struct.unpack(">I", ihdr[4:8])[0]
+    return width, height
+
+
+def _file_hash(filepath: Path) -> str:
+    """Compute SHA-256 hash of a file."""
+    h = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compare_screenshots(baseline_path: Path, current_path: Path) -> dict:
+    """
+    Compare two PNG screenshots using hash and dimension checks.
+
+    Returns dict with:
+      - match: True if screenshots are identical
+      - reason: human-readable explanation
+      - baseline_hash, current_hash: SHA-256 hashes
+      - baseline_size, current_size: (width, height) tuples
+    """
+    if not baseline_path.exists():
+        return {
+            "match": False,
+            "reason": "baseline missing",
+        }
+
+    if not current_path.exists():
+        return {
+            "match": False,
+            "reason": "current screenshot missing",
+        }
+
+    # Quick hash comparison — if identical bytes, it's a match
+    b_hash = _file_hash(baseline_path)
+    c_hash = _file_hash(current_path)
+
+    if b_hash == c_hash:
+        return {
+            "match": True,
+            "reason": "identical",
+            "baseline_hash": b_hash[:12],
+            "current_hash": c_hash[:12],
+        }
+
+    # Hashes differ — check dimensions to provide useful diagnostics
+    try:
+        b_dims = _png_dimensions(baseline_path)
+        c_dims = _png_dimensions(current_path)
+    except Exception as e:
+        return {
+            "match": False,
+            "reason": f"failed to read PNG headers: {e}",
+            "baseline_hash": b_hash[:12],
+            "current_hash": c_hash[:12],
+        }
+
+    if b_dims != c_dims:
+        return {
+            "match": False,
+            "reason": f"dimension mismatch: baseline {b_dims[0]}x{b_dims[1]} vs current {c_dims[0]}x{c_dims[1]}",
+            "baseline_hash": b_hash[:12],
+            "current_hash": c_hash[:12],
+            "baseline_size": b_dims,
+            "current_size": c_dims,
+        }
+
+    # Same dimensions, different content
+    b_bytes = baseline_path.stat().st_size
+    c_bytes = current_path.stat().st_size
+    return {
+        "match": False,
+        "reason": f"pixel differences detected (same dimensions {b_dims[0]}x{b_dims[1]}, file size {b_bytes} vs {c_bytes} bytes)",
+        "baseline_hash": b_hash[:12],
+        "current_hash": c_hash[:12],
+        "baseline_size": b_dims,
+        "current_size": c_dims,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Screenshot capture
+# ---------------------------------------------------------------------------
+
+
+def _screenshot_name(page_path: str, viewport_name: str) -> str:
+    """Generate a filename from page path and viewport name."""
+    # "/" -> "home", "/about" -> "about", "/work/ysl" -> "work-ysl"
+    if page_path == "/":
+        slug = "home"
+    else:
+        slug = page_path.strip("/").replace("/", "-")
+    return f"{slug}--{viewport_name}.png"
+
+
+def capture_screenshots(
+    output_dir: Path,
+    pages: list,
+    headless: bool = True,
+) -> list:
+    """
+    Capture screenshots of all pages at all viewports.
+    Returns a list of dicts with capture results.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+
+        for viewport_name, viewport_size in VIEWPORTS.items():
+            context = browser.new_context(
+                viewport=viewport_size,
+                device_scale_factor=1,
+                # Disable animations for consistent screenshots
+                reduced_motion="reduce",
+            )
+
+            page = context.new_page()
+
+            for page_path in pages:
+                url = f"{BASE_URL}{page_path}"
+                filename = _screenshot_name(page_path, viewport_name)
+                filepath = output_dir / filename
+
+                try:
+                    # Use "domcontentloaded" — pages with video elements may
+                    # never fire "load" due to streaming media
+                    page.goto(url, wait_until="domcontentloaded", timeout=30000)
+
+                    # Wait for layout to settle, fonts and images to render
+                    page.wait_for_timeout(2500)
+
+                    # Capture full-page screenshot
+                    page.screenshot(path=str(filepath), full_page=True)
+
+                    results.append(
+                        {
+                            "page": page_path,
+                            "viewport": viewport_name,
+                            "file": filename,
+                            "status": "ok",
+                        }
+                    )
+                    print(f"  OK  {viewport_name:>7}  {page_path}")
+
+                except Exception as e:
+                    results.append(
+                        {
+                            "page": page_path,
+                            "viewport": viewport_name,
+                            "file": filename,
+                            "status": "error",
+                            "error": str(e),
+                        }
+                    )
+                    print(f"  FAIL {viewport_name:>7}  {page_path}: {e}")
+
+            context.close()
+
+        browser.close()
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Visual regression tests for HAUS Creative portfolio"
+    )
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help="Capture baseline screenshots (overwrites existing baselines)",
+    )
+    parser.add_argument(
+        "--page",
+        type=str,
+        default=None,
+        help="Test a single page path (e.g. /about). Default: all pages.",
+    )
+    parser.add_argument(
+        "--headed",
+        action="store_true",
+        help="Run browser in headed mode (visible window)",
+    )
+    args = parser.parse_args()
+
+    # Filter pages if --page is specified
+    pages = PAGES
+    if args.page:
+        if args.page not in PAGES:
+            print(f"Unknown page: {args.page}")
+            print(f"Available pages: {', '.join(PAGES)}")
+            sys.exit(1)
+        pages = [args.page]
+
+    if args.baseline:
+        # ---- Baseline mode ----
+        print(
+            f"\nCapturing baselines for {len(pages)} page(s) "
+            f"x {len(VIEWPORTS)} viewport(s)..."
+        )
+        print(f"Output: {BASELINE_DIR}\n")
+
+        results = capture_screenshots(BASELINE_DIR, pages, headless=not args.headed)
+
+        ok_count = sum(1 for r in results if r["status"] == "ok")
+        fail_count = sum(1 for r in results if r["status"] == "error")
+        total = len(results)
+
+        print(f"\nBaseline capture complete: {ok_count}/{total} succeeded")
+        if fail_count > 0:
+            print(f"  {fail_count} failed — check errors above")
+            sys.exit(1)
+
+    else:
+        # ---- Comparison mode ----
+        print(
+            f"\nCapturing current screenshots for {len(pages)} page(s) "
+            f"x {len(VIEWPORTS)} viewport(s)..."
+        )
+        print(f"Output: {CURRENT_DIR}\n")
+
+        capture_results = capture_screenshots(
+            CURRENT_DIR, pages, headless=not args.headed
+        )
+
+        capture_errors = [r for r in capture_results if r["status"] == "error"]
+        if capture_errors:
+            print(f"\n{len(capture_errors)} capture error(s):")
+            for r in capture_errors:
+                print(f"  {r['viewport']} {r['page']}: {r['error']}")
+
+        # Compare against baselines
+        print("\nComparing against baselines...\n")
+        comparison_results = []
+        passed = 0
+        failed = 0
+        skipped = 0
+
+        for r in capture_results:
+            if r["status"] == "error":
+                skipped += 1
+                continue
+
+            baseline_path = BASELINE_DIR / r["file"]
+            current_path = CURRENT_DIR / r["file"]
+
+            cmp = compare_screenshots(baseline_path, current_path)
+            cmp["page"] = r["page"]
+            cmp["viewport"] = r["viewport"]
+            cmp["file"] = r["file"]
+            comparison_results.append(cmp)
+
+            if cmp["match"]:
+                print(f"  PASS {r['viewport']:>7}  {r['page']}")
+                passed += 1
+            else:
+                print(f"  FAIL {r['viewport']:>7}  {r['page']} — {cmp['reason']}")
+                failed += 1
+
+        # Summary
+        total = passed + failed + skipped
+        print(f"\n{'=' * 60}")
+        print(
+            f"Visual regression results: {passed} passed, "
+            f"{failed} failed, {skipped} skipped / {total} total"
+        )
+        print(f"{'=' * 60}")
+
+        # Write JSON report
+        report_path = CURRENT_DIR / "report.json"
+        report = {
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": failed,
+                "skipped": skipped,
+            },
+            "results": comparison_results,
+        }
+        report_path.write_text(json.dumps(report, indent=2))
+        print(f"\nReport written to: {report_path}")
+
+        if failed > 0:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "format:check": "prettier --check .",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:visual": "npm run build && python3 .agents/skills/webapp-testing/scripts/with_server.py --server 'npm start' --port 3000 -- python3 e2e/visual_test.py",
+    "test:visual:baseline": "npm run build && python3 .agents/skills/webapp-testing/scripts/with_server.py --server 'npm start' --port 3000 -- python3 e2e/visual_test.py --baseline"
   },
   "dependencies": {
     "next": "^14.1.0",


### PR DESCRIPTION
## Summary

- Adds Python Playwright-based visual regression test script (`e2e/visual_test.py`)
- Captures screenshots of all 14 routes at desktop (1920×1080) and mobile (375×812) viewports
- Hash-based comparison with PNG dimension diagnostics for fast pass/fail detection
- Two npm scripts: `test:visual` (compare against baselines) and `test:visual:baseline` (capture reference screenshots)

## How to use

```bash
# First run: capture baselines
npm run test:visual:baseline

# After code changes: compare against baselines
npm run test:visual

# Test a single page
python3 e2e/visual_test.py --page /about
```

## Notes

- Screenshots are gitignored (~106MB for full suite) — regenerate baselines locally
- Pages with video content (homepage, Wao Cosmo, Bucherer Summer) will have natural variation due to video frame timing
- Uses `domcontentloaded` wait strategy to avoid timeout on streaming video pages
- Requires Python 3 with Playwright installed (`pip install playwright && playwright install chromium`)
- No new npm dependencies added