### PR TITLE
Home: play each project's hero video as its cover

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,6 +55,7 @@ export default function Home() {
           <WorkGalleryItem
             key={project.id}
             project={project}
+            heroVideo={detail?.heroVideo}
             galleryMedia={galleryMedia}
             carouselConfig={hasHomepageCarousel ? carouselConfig : undefined}
           />

--- a/src/components/home/WorkGalleryItem.tsx
+++ b/src/components/home/WorkGalleryItem.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { MediaRenderer, SimpleCarousel } from "@/components/ui";
+import { HeroVideo, MediaRenderer, SimpleCarousel } from "@/components/ui";
 import { useSlideInOnView } from "@/hooks/useSlideInOnView";
 import type { Project } from "@/config/site";
-import type { ProjectMedia } from "@/config/projects";
+import type { ProjectDetail, ProjectMedia } from "@/config/projects";
 import type { CarouselConfig } from "@/types/carousel";
 
 interface WorkGalleryItemProps {
   project: Project;
+  /**
+   * The project page's hero video — when provided, plays as the cover with the
+   * same per-breakpoint sources as /work/[slug]. The static media stays
+   * underneath as the loading backdrop and as the fallback on breakpoints the
+   * video doesn't cover (e.g. MC Arabia is mobile-only). Home tiles are
+   * full-bleed, so the video always object-covers regardless of the project
+   * page's objectFit.
+   */
+  heroVideo?: ProjectDetail["heroVideo"];
   /** Gallery media for carousel display. When provided with carouselConfig, renders a carousel instead of a single image. */
   galleryMedia?: ProjectMedia[];
   /** Carousel animation/timing config. Required alongside galleryMedia for carousel mode. */
@@ -30,6 +39,7 @@ interface WorkGalleryItemProps {
  */
 export function WorkGalleryItem({
   project,
+  heroVideo,
   galleryMedia,
   carouselConfig,
 }: WorkGalleryItemProps) {
@@ -53,10 +63,21 @@ export function WorkGalleryItem({
             className="transition-opacity duration-300 group-hover:opacity-90"
           />
         ) : (
-          <MediaRenderer
-            media={project.media}
-            className="h-full w-full object-cover transition-opacity duration-300 group-hover:opacity-90"
-          />
+          <>
+            <MediaRenderer
+              media={project.media}
+              className="h-full w-full object-cover transition-opacity duration-300 group-hover:opacity-90"
+            />
+            {heroVideo && (
+              <div className="absolute inset-0 transition-opacity duration-300 group-hover:opacity-90">
+                <HeroVideo
+                  desktop={heroVideo.desktop}
+                  mobile={heroVideo.mobile}
+                  poster={heroVideo.poster}
+                />
+              </div>
+            )}
+          </>
         )}
       </Link>
 


### PR DESCRIPTION
## Home covers now mirror each project page's hero video

Each work tile on the home page layers the project's `heroVideo` (read straight from the project config — no duplicated paths) over the existing static cover via the shared `HeroVideo` client island, so home inherits every per-breakpoint decision already made on the project pages.

### Behaviour per cover
- **Video, desktop + mobile:** Vivara, Life, BFJ, Ouronyx, Bride Story, Harrods, YSL
- **Marie Claire Arabia:** video on mobile only; desktop keeps the static cover (Figma tag is mobile-only — same as its project page)
- **YSL mobile:** plays the desktop banner file (inherits the mis-export workaround; heals automatically when the re-export lands, CLIENT-ASKS #1)
- **Static (no hero video exists on their pages):** SK (intro hero + tile), Bucherer Summer, WAO Cosmo

### Mechanics
- Static image stays underneath as loading backdrop; the video paints over it when present, and when `HeroVideo` renders null (desktop on a mobile-only hero) the image simply shows through
- Hover dim (`group-hover:opacity-90`) applied to the video layer via a positioned wrapper, matching the image behaviour
- Homepage carousel path untouched (no project uses one)

Gates: tsc clean, ESLint clean, jest 268/268.