### PR TITLE
WAO: remove the two trailing mobile cover stills

### DIFF
--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -711,22 +711,9 @@ export const projects: ProjectDetail[] = [
         alt: "wao-cosmo video 20",
         spaceBefore: { mobile: 55, desktop: 0 },
       },
-      {
-        type: "image",
-        desktop: "/assets/wao-cosmo/wao-cosmo-21.webp",
-        mobile: "/assets/wao-cosmo/wao-cosmo-22-mobile.webp",
-        alt: "wao-cosmo image 21 (mobile)",
-        mobileOnly: true,
-        spaceBefore: { mobile: 55, desktop: 0 },
-      },
-      {
-        type: "image",
-        desktop: "/assets/wao-cosmo/wao-cosmo-20.webp",
-        mobile: "/assets/wao-cosmo/wao-cosmo-23-mobile.webp",
-        alt: "wao-cosmo image 22 (mobile)",
-        mobileOnly: true,
-        spaceBefore: { mobile: 55, desktop: 0 },
-      },
+      // The two trailing mobileOnly stills (wao-cosmo-21/20 covers) were
+      // removed per review 2026-07-15 — they duplicated the clips above
+      // them once videos 20/21 started playing on mobile.
     ],
 
     metaTitle: "Wao Cosmo | HAUS Creative",


### PR DESCRIPTION
Per review: the last two mobileOnly image slots (badges `wao-cosmo-21`/`wao-cosmo-20`) were the cover stills of videos 20/21 — kept from before the clips were wired. Now that both clips play on mobile, the stills duplicated them directly below.

Config-only removal; both items were mobileOnly and at the array tail, so desktop and pair flow are untouched. The webp files stay on disk (still referenced as the clips' posters).

Gates: tsc clean, ESLint clean, jest 274/274.