### PR TITLE
Home: fix cover ghosting — hover dim moves to the tile

### DIFF
--- a/src/components/home/WorkGalleryItem.tsx
+++ b/src/components/home/WorkGalleryItem.tsx
@@ -50,9 +50,12 @@ export function WorkGalleryItem({
   return (
     <section className="relative h-dvh w-full overflow-clip pt-[5vh]">
       {/* Media Background - absolute positioned layer */}
+      {/* Hover dim lives on the Link (the whole tile as one unit): with the
+          static cover layered UNDER the hero video, per-layer opacity let
+          the mismatched still ghost through the translucent video. */}
       <Link
         href={project.href}
-        className="absolute inset-0 block group"
+        className="absolute inset-0 block transition-opacity duration-300 hover:opacity-90"
         aria-label={`View ${project.title} project`}
       >
         {useCarousel ? (
@@ -60,16 +63,15 @@ export function WorkGalleryItem({
             items={galleryMedia}
             animation={carouselConfig.animation}
             autoAdvanceTime={carouselConfig.autoAdvanceTime}
-            className="transition-opacity duration-300 group-hover:opacity-90"
           />
         ) : (
           <>
             <MediaRenderer
               media={project.media}
-              className="h-full w-full object-cover transition-opacity duration-300 group-hover:opacity-90"
+              className="h-full w-full object-cover"
             />
             {heroVideo && (
-              <div className="absolute inset-0 transition-opacity duration-300 group-hover:opacity-90">
+              <div className="absolute inset-0">
                 <HeroVideo
                   desktop={heroVideo.desktop}
                   mobile={heroVideo.mobile}


### PR DESCRIPTION
Bug: with the hero video layered over the static cover (PR #47), each layer carried its own `group-hover:opacity-90`. The tiles fill the viewport, so the cursor is effectively always hovering on desktop — the video sat at 90% opacity and the mismatched still ghosted through, reading as "the video has opacity".

Fix: one `hover:opacity-90` on the Link so image + video dim together as a unit against the section background — no relative transparency between layers. Carousel path unified too; orphaned `group` class removed.

Gates: tsc clean, ESLint clean, jest 274/274.