### PR TITLE
Home: footer after the last tile (shared SiteFooter)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { IntroHero, WorkGalleryItem } from "@/components/home";
+import { SiteFooter } from "@/components/layout";
 import { featuredProjects } from "@/config/site";
 import { projects } from "@/config/projects";
 import type { ProjectMedia } from "@/config/projects";
@@ -61,6 +62,10 @@ export default function Home() {
           />
         );
       })}
+
+      {/* Footer after the last tile (client ask, 2026-07-16) — same shared
+          footer as the project pages. */}
+      <SiteFooter />
     </>
   );
 }

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,9 +1,8 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import Image from "next/image";
 import { getAllProjectSlugs, getProjectBySlug } from "@/config/projects";
 import { GalleryGrid, HeroVideo } from "@/components/ui";
-import { siteConfig } from "@/config/site";
+import { SiteFooter } from "@/components/layout";
 import type { Metadata } from "next";
 
 interface ProjectPageProps {
@@ -315,40 +314,8 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         )}
 
         {/* Divider — both mobile + desktop per updated Figma */}
-        <div className="px-[17px] md:px-[34px] mt-[71px] md:mt-[81px] md:pr-[44px]">
-          <div className="w-full h-[0.5px] bg-black" />
-        </div>
-
-        {/* Footer Section */}
-        <div className="px-[21px] md:px-[41px] md:pr-[44px]">
-          {/* Mobile: stacked vertically. Desktop: email left, social right */}
-          <div className="flex flex-col md:flex-row md:justify-between pt-[71px] md:pt-[60px] pb-[60px] md:pb-[40px]">
-            {/* Contact Email — plain <a> for native mailto: handling */}
-            <div>
-              <a
-                href={`mailto:${siteConfig.email}`}
-                className="text-[15px] leading-[1.21em] hover:opacity-50 transition-opacity"
-              >
-                {siteConfig.email}
-              </a>
-            </div>
-
-            {/* Social Links - vertical on mobile, horizontal on desktop */}
-            <div className="flex flex-col md:flex-row gap-[18px] md:gap-[21px] mt-[38px] md:mt-0">
-              {siteConfig.socialLinks.map((link) => (
-                <Link
-                  key={link.title}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[15px] leading-[1.21em] hover:opacity-50 transition-opacity"
-                >
-                  {link.title}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </div>
+        {/* Footer Section — shared component (also on home) */}
+        <SiteFooter />
       </section>
     </div>
   );

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { siteConfig } from "@/config/site";
+
+/**
+ * Site footer — hairline divider, contact email left, social links right
+ * (stacked on mobile). Extracted verbatim from the project-page footer so
+ * home and /work/[slug] share one source of truth.
+ */
+export function SiteFooter() {
+  return (
+    <div className="bg-white text-black">
+      <div className="px-[17px] md:px-[34px] mt-[71px] md:mt-[81px] md:pr-[44px]">
+        <div className="w-full h-[0.5px] bg-black" />
+      </div>
+
+      <div className="px-[21px] md:px-[41px] md:pr-[44px]">
+        {/* Mobile: stacked vertically. Desktop: email left, social right */}
+        <div className="flex flex-col md:flex-row md:justify-between pt-[71px] md:pt-[60px] pb-[60px] md:pb-[40px]">
+          {/* Contact Email — plain <a> for native mailto: handling */}
+          <div>
+            <a
+              href={`mailto:${siteConfig.email}`}
+              className="text-[15px] leading-[1.21em] hover:opacity-50 transition-opacity"
+            >
+              {siteConfig.email}
+            </a>
+          </div>
+
+          {/* Social Links - vertical on mobile, horizontal on desktop */}
+          <div className="flex flex-col md:flex-row gap-[18px] md:gap-[21px] mt-[38px] md:mt-0">
+            {siteConfig.socialLinks.map((link) => (
+              <Link
+                key={link.title}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[15px] leading-[1.21em] hover:opacity-50 transition-opacity"
+              >
+                {link.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,4 +1,5 @@
 export { Header } from "./Header";
+export { SiteFooter } from "./SiteFooter";
 export { MobileMenu } from "./MobileMenu";
 export { ScrollManager } from "./ScrollManager";
 export { PageTransition } from "./PageTransition";


### PR DESCRIPTION
Client ask: the home page gets the same footer as the project pages (hairline divider, contact email left, social links right, stacked on mobile).

Extracted the project-page footer verbatim into `SiteFooter` (components/layout) and mounted it in both places — one source of truth, zero visual change on /work/[slug]. On home it renders on white after the Ouronyx tile.

Gates: tsc clean, ESLint clean, jest 274/274.