### PR TITLE
Bride Story: hero video scales whole-frame on desktop

### DIFF
--- a/src/__tests__/app/work-slug.test.tsx
+++ b/src/__tests__/app/work-slug.test.tsx
@@ -155,8 +155,14 @@ describe("ProjectPage", () => {
       );
       const section = container.querySelector("#project-hero");
       expect(section).toBeInTheDocument();
-      expect(section!.className).not.toContain("md:h-auto");
-      expect(section!.className).toMatch(/h-dvh/);
+      if (project.heroVideo?.objectFit === "contain") {
+        // Whole-frame video mode (Bride): md:h-auto is collapse-safe here
+        // because the md aspect box gives the section intrinsic height.
+        expect(section!.className).toContain("md:aspect-[1920/1080]");
+      } else {
+        expect(section!.className).not.toContain("md:h-auto");
+        expect(section!.className).toMatch(/h-dvh/);
+      }
       unmount();
     });
   });

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -73,9 +73,15 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         id="project-hero"
         className={`relative w-full bg-black overflow-hidden ${
           project.heroVideo?.desktop
-            ? project.heroImage?.mobile
-              ? "aspect-[440/864] md:aspect-auto md:h-dvh"
-              : "h-dvh"
+            ? project.heroVideo.objectFit === "contain"
+              ? // Whole-frame video hero (e.g. Bride's baked left-edge title,
+                // which cover-crop cut on narrow windows): desktop renders a
+                // natural-aspect 16:9 band that scales with the viewport;
+                // mobile keeps the 440/864 design box (its own portrait edit).
+                "aspect-[440/864] md:aspect-[1920/1080] md:h-auto"
+              : project.heroImage?.mobile
+                ? "aspect-[440/864] md:aspect-auto md:h-dvh"
+                : "h-dvh"
             : project.heroImage?.objectFit === "contain"
               ? project.heroImage?.mobileFit === "natural"
                 ? "h-auto"

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -1701,6 +1701,11 @@ export const projects: ProjectDetail[] = [
       desktop: "/assets/bride-story/bride-story-hero-video.mp4",
       mobile: "/assets/bride-story/bride-story-hero-video-mobile.mp4",
       poster: "/assets/bride-story/bride-story-hero-cover.webp",
+      // The baked "BRIDE" title sits at the frame's left edge — cover-crop
+      // cut it on narrower desktop windows (review 2026-07-20). Contain
+      // renders the whole 1920×1080 frame as a natural-aspect band on
+      // desktop (the same treatment the static Bride hero always had).
+      objectFit: "contain",
       // Desktop banner has a full mix; the delivered mobile export ships a
       // digitally silent track (max −91 dB), so no toggle below md.
       hasAudio: { desktop: true, mobile: false },


### PR DESCRIPTION
Bug (review 2026-07-20): the hero renders `object-fit: cover` in an h-dvh box, so narrowing the window crops from the center — and the baked "BRIDE" title sits at the frame's left edge, so it was the first casualty ("RIDE" at ~1700px).

Fix: the pre-video Bride hero already solved this with a contain/natural-aspect mode (the page comment names the BRIDE text). This restores it for the video era: `heroVideo.objectFit: "contain"` renders the whole 1920×1080 frame as a natural-aspect band on desktop that scales with the viewport — the title is always visible. Mobile keeps the 440/864 box with its own portrait edit (unchanged).

Regression test updated: the collapse guard now allows md:h-auto when the md aspect box provides intrinsic height.

Gates: tsc clean, ESLint clean, jest 274/274.