### PR TITLE
MC Arabia: natural-fit mobile hero — masthead un-cropped

### DIFF
--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -249,6 +249,10 @@ export const projects: ProjectDetail[] = [
       mobile: "/assets/mc-arabia/mc-arabia-hero-mobile.webp",
       alt: "Marie Claire Arabia September Issue editorial",
       objectFit: "contain",
+      // The mobile still bakes the "marie claire" masthead to the frame
+      // edge — cover-crop clipped it once the mobile hero went static
+      // (review 2026-07-20); natural renders the 440×864 cover art whole.
+      mobileFit: "natural",
     },
 
     year: "2024",


### PR DESCRIPTION
Follow-up to #61 (static mobile hero): the mobile still is the delivered MC_MOB_01 cover art with the "marie claire" masthead baked in — the h-dvh cover-crop clipped it at the right edge. `mobileFit: "natural"` renders the whole 440×864 cover art un-cropped (the existing mechanism for edge-content mobile assets). Verified: the shipped webp is byte-identical to a fresh MC_MOB_01 conversion, so the asset itself was already correct.

Gates: tsc clean, ESLint clean, jest 274/274.