### PR TITLE
feat(home): update slide-in project names per client list

### DIFF
--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -149,7 +149,7 @@ export const featuredProjects: Project[] = [
   // 2. YSL
   {
     id: "ysl",
-    title: "Yves Saint Laurent",
+    title: "Yves Saint Laurent Beauty",
     subtitle: "Art Direction",
     href: "/work/ysl",
     media: {
@@ -175,7 +175,7 @@ export const featuredProjects: Project[] = [
   // 4. WAO
   {
     id: "wao-cosmo",
-    title: "Wao Cosmo",
+    title: "WAOMAG",
     subtitle: "Visual Design",
     href: "/work/wao-cosmo",
     media: {
@@ -214,7 +214,7 @@ export const featuredProjects: Project[] = [
   // 7. BFJ
   {
     id: "bfj",
-    title: "BFJ",
+    title: "Bucherer Fine Jewellery",
     subtitle: "Digital Design",
     href: "/work/bfj",
     media: {
@@ -227,7 +227,7 @@ export const featuredProjects: Project[] = [
   // 8. SK-II
   {
     id: "sk",
-    title: "SK",
+    title: "SK-II",
     subtitle: "Brand Development",
     href: "/work/sk",
     media: {
@@ -240,7 +240,7 @@ export const featuredProjects: Project[] = [
   // 9. Life
   {
     id: "life",
-    title: "Life",
+    title: "Life by Vivara",
     subtitle: "Creative Strategy",
     href: "/work/life",
     media: {
@@ -253,7 +253,7 @@ export const featuredProjects: Project[] = [
   // 10. Bride Story
   {
     id: "bride-story",
-    title: "Bride Story",
+    title: "BRIDE",
     subtitle: "Art Direction",
     href: "/work/bride-story",
     media: {
@@ -266,7 +266,7 @@ export const featuredProjects: Project[] = [
   // 11. Bucherer Summer
   {
     id: "bucherer-summer",
-    title: "Bucherer Summer",
+    title: "BUCHERER",
     subtitle: "Creative Direction",
     href: "/work/bucherer-summer",
     media: {


### PR DESCRIPTION
Vitor's WhatsApp list (2026-07-23) — the names that slide in over the home tiles. Same list feeds /work, so both pages update together.

| Tile | Before | After |
|---|---|---|
| YSL | Yves Saint Laurent | Yves Saint Laurent Beauty |
| WAO | Wao Cosmo | WAOMAG |
| BFJ | BFJ | Bucherer Fine Jewellery |
| SK-II | SK | SK-II |
| Life | Life | Life by Vivara |
| Bride | Bride Story | BRIDE |
| Bucherer Summer | Bucherer Summer | BUCHERER |

Vivara, Harrods and Marie Claire Arabia already matched. "Ouronuyx" in the client list is a typo — kept the correct **Ouronyx** spelling (matches the project page's OURONYX title). Order unchanged; intro banner untouched.

Config-only change (`site.ts` titles); gates green (tsc, eslint, jest 274/274).