### PR TITLE
feat(work): intro titles break at the hyphen; wider description column

### DIFF
--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -238,13 +238,15 @@ export default function ProjectPage({ params }: ProjectPageProps) {
       <section className="bg-white">
         {/* Intro Section — two-column layout below hero.
             Left: title + campaign tagline (uppercase) + agency line.
-            Right: description body. Mobile: stacked single column. */}
+            Right: description body. Mobile: stacked single column.
+            Column caps sized so the longest campaign title holds one
+            line at 33px (~590px in Inter) — client review 2026-07-23. */}
         <div className="px-[21px] md:px-[34px] pt-[70px] md:pt-[70px]">
           <div className="flex flex-col gap-[24px] md:flex-row md:gap-[60px]">
             {/* Left column: title + discipline (uppercase) + location +
                 agency — lines render only when the client copy provides
                 them (order per the 2026-07-20 text delivery). */}
-            <div className="flex-1 md:max-w-[400px]">
+            <div className="flex-1 md:max-w-[600px]">
               <h1 className="text-[26px] min-[400px]:text-[33px] leading-[1.03em] font-normal mb-[18px]">
                 {project.title}
               </h1>
@@ -269,7 +271,7 @@ export default function ProjectPage({ params }: ProjectPageProps) {
             {/* Right column: intro body — one <p> per paragraph. Desktop
                 unchanged; mobile stacks tightly under the agency (gap-24,
                 was 49 — Figma #20). */}
-            <div className="flex-1 md:max-w-[460px] space-y-[1em]">
+            <div className="flex-1 md:max-w-[560px] space-y-[1em]">
               {(Array.isArray(project.introText)
                 ? project.introText
                 : [project.introText ?? project.description]

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import { getAllProjectSlugs, getProjectBySlug } from "@/config/projects";
@@ -56,6 +57,12 @@ export default function ProjectPage({ params }: ProjectPageProps) {
     "";
   const heroMatch = heroSrc.match(/\/([^/]+)\.(?:webp|mp4|jpg|png)$/i);
   const heroLabel = heroMatch ? heroMatch[1] : "hero";
+
+  // The " - " in a campaign title is a line delimiter (client review
+  // 2026-07-23): brand on the first line (keeping its hyphen), campaign
+  // beneath. Hyphen-less titles render as-is. The bare hyphen in "SK-II"
+  // is untouched — only the spaced separator splits.
+  const titleParts = project.title.split(" - ");
 
   return (
     <div id="top" className="min-h-screen bg-white text-black">
@@ -239,16 +246,23 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         {/* Intro Section — two-column layout below hero.
             Left: title + campaign tagline (uppercase) + agency line.
             Right: description body. Mobile: stacked single column.
-            Column caps sized so the longest campaign title holds one
-            line at 33px (~590px in Inter) — client review 2026-07-23. */}
+            Title cap sized so the longest hyphen-split line ("The
+            Summer of Indulgence", ~415px in Inter at 33px) holds one
+            line while short titles stay near the description body —
+            client review 2026-07-23. */}
         <div className="px-[21px] md:px-[34px] pt-[70px] md:pt-[70px]">
           <div className="flex flex-col gap-[24px] md:flex-row md:gap-[60px]">
             {/* Left column: title + discipline (uppercase) + location +
                 agency — lines render only when the client copy provides
                 them (order per the 2026-07-20 text delivery). */}
-            <div className="flex-1 md:max-w-[600px]">
+            <div className="flex-1 md:max-w-[430px]">
               <h1 className="text-[26px] min-[400px]:text-[33px] leading-[1.03em] font-normal mb-[18px]">
-                {project.title}
+                {titleParts.map((part, i) => (
+                  <Fragment key={i}>
+                    {i > 0 && <br />}
+                    {i < titleParts.length - 1 ? `${part} -` : part}
+                  </Fragment>
+                ))}
               </h1>
               {project.editorialSubtitle && (
                 <p className="text-[14px] leading-[1.4em] uppercase tracking-wide mb-[14px]">

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -59,8 +59,8 @@ export default function ProjectPage({ params }: ProjectPageProps) {
   const heroLabel = heroMatch ? heroMatch[1] : "hero";
 
   // The " - " in a campaign title is a line delimiter (client review
-  // 2026-07-23): brand on the first line (keeping its hyphen), campaign
-  // beneath. Hyphen-less titles render as-is. The bare hyphen in "SK-II"
+  // 2026-07-23): brand on the first line, campaign beneath, separator
+  // dropped. Hyphen-less titles render as-is. The bare hyphen in "SK-II"
   // is untouched — only the spaced separator splits.
   const titleParts = project.title.split(" - ");
 
@@ -260,7 +260,7 @@ export default function ProjectPage({ params }: ProjectPageProps) {
                 {titleParts.map((part, i) => (
                   <Fragment key={i}>
                     {i > 0 && <br />}
-                    {i < titleParts.length - 1 ? `${part} -` : part}
+                    {part}
                   </Fragment>
                 ))}
               </h1>

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -1246,7 +1246,7 @@ export const projects: ProjectDetail[] = [
     id: "bucherer-summer",
     slug: "bucherer-summer",
     client: "Bucherer",
-    title: "Bucherer - The Summer of Indulgence",
+    title: "BUCHERER - The Summer of Indulgence",
     subtitle: "Creative Direction",
     description:
       "The Summer of Indulgence was a 360° campaign celebrating the pleasures of the season while showcasing Bucherer's jewellery, watches and luxury retail experience.",


### PR DESCRIPTION
Vitor (2026-07-23), revised after seeing the one-line version: "tinha pensando YSL BEAUTY numa linha, The Golden Celebration na de baixo, pq senao os nomes que forem menor vao ficar muito distante da descricao".

Template-wide on /work/[slug] (all 11 projects):

- **Titles split at their " - " separator** — brand on the first line (hyphen kept), campaign name beneath. Hyphen-less titles (Marie Claire Arabia, WAOMAG Showcase, BRIDE Magazine, Harrods Restaurants) render one line as before. The bare hyphen in "SK-II" is untouched — only the spaced separator splits.
- **Title column cap 400 → 430px** — just enough for the longest split line ("The Summer of Indulgence", ~415px in Inter at 33px), keeping short titles close to the description per Vitor's note.
- **Description column cap 460 → 560px** — kept from the first round: longer lines, fewer of them.

Same rule applies on mobile, where breaking at the hyphen reads cleaner than the arbitrary wrap it replaces.

Gates green (tsc, eslint, jest 274/274).