### PR TITLE
fix(meta): browser-tab titles say STUDIO HAUS

### DIFF
--- a/src/__tests__/app/work-slug.test.tsx
+++ b/src/__tests__/app/work-slug.test.tsx
@@ -308,8 +308,7 @@ describe("generateMetadata", () => {
     const project = getProjectBySlug(slug)!;
     const metadata = await generateMetadata({ params: { slug } });
 
-    const expectedTitle =
-      project.metaTitle || `${project.title} | HAUS Creative`;
+    const expectedTitle = project.metaTitle || project.title;
     expect(metadata.title).toBe(expectedTitle);
   });
 
@@ -322,7 +321,7 @@ describe("generateMetadata", () => {
     });
 
     const metadata = await generateMetadata({ params: { slug: projects[0].slug } });
-    expect(metadata.title).toBe(`${originalProject.title} | HAUS Creative`);
+    expect(metadata.title).toBe(originalProject.title);
   });
 
   it("falls back to project description when metaDescription is absent", async () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://studiohauscreative.
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
-    default: `${siteConfig.name} | Creative Direction + Design`,
+    default: siteConfig.name,
     template: `%s | ${siteConfig.name}`,
   },
   description: siteConfig.description,
@@ -32,12 +32,12 @@ export const metadata: Metadata = {
     locale: "en_GB",
     url: siteUrl,
     siteName: "Studio Haus Creative",
-    title: `${siteConfig.name} | Creative Direction + Design`,
+    title: siteConfig.name,
     description: siteConfig.description,
   },
   twitter: {
     card: "summary_large_image",
-    title: `${siteConfig.name} | Creative Direction + Design`,
+    title: siteConfig.name,
     description: siteConfig.description,
   },
   robots: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import type { ProjectMedia } from "@/config/projects";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "HAUS | Creative Direction + Design",
+  // No title override — the root default ("STUDIO HAUS") applies untemplated.
   description:
     "Studio Haus Creative specialises in 360° campaigns, branded content, and immersive digital experiences for luxury and forward-thinking brands.",
   alternates: {

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -20,7 +20,8 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<Me
   if (!project) return {};
 
   return {
-    title: project.metaTitle || `${project.title} | HAUS Creative`,
+    // Bare name only — the root layout template appends "| STUDIO HAUS".
+    title: project.metaTitle || project.title,
     description: project.metaDescription || project.description,
     alternates: {
       canonical: `/work/${params.slug}`,

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -345,7 +345,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "Marie Claire Arabia | HAUS Creative",
+    metaTitle: "Marie Claire Arabia",
     metaDescription:
       "Creative direction for Marie Claire Arabia September Issue - Back to Work Editorial by Studio Haus Creative.",
     ogImage: "/assets/mc-arabia/mc-arabia-hero.webp",
@@ -513,7 +513,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "YSL | HAUS Creative",
+    metaTitle: "Yves Saint Laurent Beauty",
     metaDescription:
       "Art direction for Yves Saint Laurent by Studio Haus Creative.",
     ogImage: "/assets/ysl/ysl-1.webp",
@@ -733,7 +733,7 @@ export const projects: ProjectDetail[] = [
       // them once videos 20/21 started playing on mobile.
     ],
 
-    metaTitle: "Wao Cosmo | HAUS Creative",
+    metaTitle: "WAOMAG",
     metaDescription:
       "Visual identity and brand design for Wao Cosmo by Studio Haus Creative.",
     ogImage: "/assets/wao-cosmo/wao-cosmo-1.webp",
@@ -911,7 +911,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "Vivara | HAUS Creative",
+    metaTitle: "Vivara",
     metaDescription:
       "Art direction for Vivara jewellery campaigns by Studio Haus Creative.",
     ogImage: "/assets/vivara/vivara-1.webp",
@@ -1061,7 +1061,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "Life | HAUS Creative",
+    metaTitle: "Life by Vivara",
     metaDescription:
       "Creative strategy and visual direction for Life by Studio Haus Creative.",
     ogImage: "/assets/life/life-1.webp",
@@ -1228,7 +1228,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "SK | HAUS Creative",
+    metaTitle: "SK-II",
     metaDescription:
       "Brand development and visual identity for SK by Studio Haus Creative.",
     ogImage: "/assets/sk/sk-1.webp",
@@ -1330,7 +1330,7 @@ export const projects: ProjectDetail[] = [
       { role: "Post Production", name: "Spring Studios" },
     ],
 
-    metaTitle: "Bucherer Summer | HAUS Creative",
+    metaTitle: "BUCHERER",
     metaDescription:
       "Creative direction for Bucherer Summer campaign by Studio Haus Creative.",
     ogImage: "/assets/bucherer/bucherer-1.webp",
@@ -1478,7 +1478,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "BFJ | HAUS Creative",
+    metaTitle: "Bucherer Fine Jewellery",
     metaDescription:
       "Digital design and creative direction for BFJ by Studio Haus Creative.",
     ogImage: "/assets/bfj/bfj-1.webp",
@@ -1731,7 +1731,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "Ouronyx | HAUS Creative",
+    metaTitle: "Ouronyx",
     metaDescription:
       "Premium digital experience for luxury brand Ouronyx by Studio Haus Creative.",
     ogImage: "/assets/ouronyx/ouronyx-1.webp",
@@ -1873,7 +1873,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "Bride Story | HAUS Creative",
+    metaTitle: "BRIDE",
     metaDescription:
       "Art direction and visual storytelling for Bride Story by Studio Haus Creative.",
     ogImage: "/assets/bride-story/bride-story-1.webp",
@@ -2180,7 +2180,7 @@ export const projects: ProjectDetail[] = [
       },
     ],
 
-    metaTitle: "Harrods | HAUS Creative",
+    metaTitle: "Harrods",
     metaDescription:
       "Creative direction for the Harrods Dining Hall experience by Studio Haus Creative.",
     ogImage: "/assets/harrods/harrods-1.webp",

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -105,7 +105,9 @@ export interface SiteConfig {
 // =============================================================================
 
 export const siteConfig: SiteConfig = {
-  name: "HAUS",
+  // Browser-tab / metadata brand — "STUDIO HAUS", never "HAUS Creative"
+  // (client note 2026-07-23).
+  name: "STUDIO HAUS",
   description:
     "We are a creative studio specializing in digital experiences, brand identity, and immersive design for forward-thinking brands.",
   email: "contact@studiohauscreative.com",


### PR DESCRIPTION
Vitor (2026-07-23): "O titulo do site tb tem que ser apenas STUDIO HAUS (nao HAUS Creative)."

The tab in his screenshot ("YSL | HAUS Creative | HAU…") was a double suffix: project metaTitles baked " | HAUS Creative" AND the root template appended " | HAUS". Now:

- `siteConfig.name` = **STUDIO HAUS** — the root template (`%s | STUDIO HAUS`) is the only place branding is appended.
- Home tab: plain **STUDIO HAUS** (dropped the "HAUS | Creative Direction + Design" override; og/twitter titles follow).
- Project metaTitles are bare names, aligned to the current naming (Yves Saint Laurent Beauty, WAOMAG, Bucherer Fine Jewellery, SK-II, Life by Vivara, BRIDE, BUCHERER, …) → tabs read "WAOMAG | STUDIO HAUS" etc.
- Work/About/Contact already used the template → "Work | STUDIO HAUS", ….
- og `siteName`/authors stay "Studio Haus Creative" (the studio's legal-ish name, not tab branding).

Gates green (tsc, eslint, jest 274/274, pipefail on).