### PR TITLE
fix: credits formatting + footer placement per review

### DIFF
--- a/src/__tests__/app/work-slug.test.tsx
+++ b/src/__tests__/app/work-slug.test.tsx
@@ -119,8 +119,14 @@ describe("ProjectPage", () => {
 
       expect(screen.getByText("Credits")).toBeInTheDocument();
       projectWithCredits.credits!.forEach((credit) => {
-        expect(screen.getByText(credit.role)).toBeInTheDocument();
-        expect(screen.getByText(credit.name)).toBeInTheDocument();
+        // Role renders as "Role:" (no pre-colon space, review 2026-07-23);
+        // comma-joined names render one per line without the commas.
+        expect(screen.getByText(`${credit.role}:`)).toBeInTheDocument();
+        credit.name.split(", ").forEach((name) => {
+          expect(
+            screen.getAllByText(name, { exact: false }).length,
+          ).toBeGreaterThan(0);
+        });
       });
     }
   });

--- a/src/__tests__/app/work-slug.test.tsx
+++ b/src/__tests__/app/work-slug.test.tsx
@@ -119,9 +119,9 @@ describe("ProjectPage", () => {
 
       expect(screen.getByText("Credits")).toBeInTheDocument();
       projectWithCredits.credits!.forEach((credit) => {
-        // Role renders as "Role:" (no pre-colon space, review 2026-07-23);
+        // Film-credits style (review 2026-07-23): bold role line, no colon;
         // comma-joined names render one per line without the commas.
-        expect(screen.getByText(`${credit.role}:`)).toBeInTheDocument();
+        expect(screen.getByText(credit.role)).toBeInTheDocument();
         credit.name.split(", ").forEach((name) => {
           expect(
             screen.getAllByText(name, { exact: false }).length,

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -71,8 +71,10 @@ export default function ContactPage() {
           <div className="flex-1 md:max-w-[1115px]">
             <p className="text-[15px] leading-[1.53em] md:text-[18px] md:leading-[1.55em]">
               We are always looking to connect with creatives globally. We
-              operate hybrid in remote between London and São Paulo. Reach
-              out via{" "}
+              operate hybrid in remote between London and São Paulo.
+              {/* "Reach out via…" starts its own line (review 2026-07-23). */}
+              <br />
+              Reach out via{" "}
               <a
                 href={`mailto:${siteConfig.email}`}
                 className="hover:opacity-50 transition-opacity"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,8 +64,12 @@ export default function Home() {
       })}
 
       {/* Footer after the last tile (client ask, 2026-07-16) — same shared
-          footer as the project pages. */}
-      <SiteFooter />
+          footer as the project pages. Desktop-only since review 2026-07-23:
+          "só no mobile que achei estranho" — mobile home ends on the last
+          full-bleed tile. */}
+      <div className="hidden md:block">
+        <SiteFooter />
+      </div>
     </>
   );
 }

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -330,25 +330,21 @@ export default function ProjectPage({ params }: ProjectPageProps) {
               </div>
 
               {/* Content column — Figma spec: Inter 18px / 28px line-height.
-                  Review 2026-07-23: no space before the colon; comma-joined
-                  names render one per line, aligned under the first NAME
-                  (not the role) and without the commas — the flex row keeps
-                  the stacked names in their own column. */}
+                  Film-credits style (review 2026-07-23): role on its own
+                  line in bold, no colon; each comma-joined name on its own
+                  line below in normal weight, flush with the role — bold vs
+                  normal is the only differentiation. */}
               <div className="flex-1">
-                <div className="text-[18px] leading-[28px]">
+                <div className="text-[18px] leading-[28px] text-black">
                   {project.credits.map((credit, index) => (
-                    <p key={index} className="flex">
-                      <span className="shrink-0 text-black">
-                        {credit.role}:&nbsp;
-                      </span>
-                      <span className="text-black">
-                        {credit.name.split(", ").map((name, i) => (
-                          <Fragment key={i}>
-                            {i > 0 && <br />}
-                            {name}
-                          </Fragment>
-                        ))}
-                      </span>
+                    <p key={index}>
+                      <span className="font-semibold">{credit.role}</span>
+                      {credit.name.split(", ").map((name, i) => (
+                        <Fragment key={i}>
+                          <br />
+                          {name}
+                        </Fragment>
+                      ))}
                     </p>
                   ))}
                 </div>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -306,53 +306,16 @@ export default function ProjectPage({ params }: ProjectPageProps) {
         {/* Credits Section with Back-to-top link.
             Desktop: ↑ Back to top sits in the left column (where the spacer
             was), Credits label + content fill the right half.
-            Mobile: Credits stacked first, then Back to top below. */}
-        {project.credits && project.credits.length > 0 && (
-          <div className="px-[34px] md:px-0 mt-[44px] md:mt-[50px]">
-            {/* Gap above = the standard inter-asset spacing (44 mobile /
-                50 desktop) so the section break reads consistent site-wide. */}
-            <div className="flex flex-col md:flex-row">
-              {/* Back to top — desktop only, in left column */}
-              <div className="hidden md:block md:w-1/2 md:pl-[34px]">
-                <a
-                  href="#top"
-                  className="text-[14px] font-semibold leading-[1.21em] text-black hover:opacity-50 transition-opacity inline-flex items-center gap-1"
-                >
-                  <span aria-hidden>↑</span> Back to top
-                </a>
-              </div>
-
-              {/* Label column */}
-              <div className="md:w-[120px] flex-shrink-0 mb-[55px] md:mb-0">
-                <p className="text-[14px] font-semibold leading-[1.21em] text-black">
-                  Credits
-                </p>
-              </div>
-
-              {/* Content column — Figma spec: Inter 18px / 28px line-height.
-                  Film-credits style (review 2026-07-23): role on its own
-                  line in bold, no colon; each comma-joined name on its own
-                  line below in normal weight, flush with the role — bold vs
-                  normal is the only differentiation. */}
-              <div className="flex-1">
-                <div className="text-[18px] leading-[28px] text-black">
-                  {project.credits.map((credit, index) => (
-                    <p key={index}>
-                      <span className="font-semibold">{credit.role}</span>
-                      {credit.name.split(", ").map((name, i) => (
-                        <Fragment key={i}>
-                          <br />
-                          {name}
-                        </Fragment>
-                      ))}
-                    </p>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Back to top — mobile only, below credits */}
-            <div className="md:hidden mt-[55px]">
+            Mobile: Credits stacked first, then Back to top below.
+            Back to top renders on EVERY project — credits are conditional
+            (Harrods/Bucherer Summer have none, review 2026-07-23: "Harrods
+            case ta sem esse back to top"). */}
+        <div className="px-[34px] md:px-0 mt-[44px] md:mt-[50px]">
+          {/* Gap above = the standard inter-asset spacing (44 mobile /
+              50 desktop) so the section break reads consistent site-wide. */}
+          <div className="flex flex-col md:flex-row">
+            {/* Back to top — desktop only, in left column */}
+            <div className="hidden md:block md:w-1/2 md:pl-[34px]">
               <a
                 href="#top"
                 className="text-[14px] font-semibold leading-[1.21em] text-black hover:opacity-50 transition-opacity inline-flex items-center gap-1"
@@ -360,8 +323,55 @@ export default function ProjectPage({ params }: ProjectPageProps) {
                 <span aria-hidden>↑</span> Back to top
               </a>
             </div>
+
+            {project.credits && project.credits.length > 0 && (
+              <>
+                {/* Label column */}
+                <div className="md:w-[120px] flex-shrink-0 mb-[55px] md:mb-0">
+                  <p className="text-[14px] font-semibold leading-[1.21em] text-black">
+                    Credits
+                  </p>
+                </div>
+
+                {/* Content column — Figma spec: Inter 18px / 28px line-height.
+                    Film-credits style (review 2026-07-23): role on its own
+                    line in bold, no colon; each comma-joined name on its own
+                    line below in normal weight, flush with the role — bold vs
+                    normal is the only differentiation. */}
+                <div className="flex-1">
+                  <div className="text-[18px] leading-[28px] text-black">
+                    {project.credits.map((credit, index) => (
+                      <p key={index}>
+                        <span className="font-semibold">{credit.role}</span>
+                        {credit.name.split(", ").map((name, i) => (
+                          <Fragment key={i}>
+                            <br />
+                            {name}
+                          </Fragment>
+                        ))}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
-        )}
+
+          {/* Back to top — mobile only, below credits (or straight after
+              the gallery when a project has none) */}
+          <div
+            className={`md:hidden ${
+              project.credits && project.credits.length > 0 ? "mt-[55px]" : ""
+            }`}
+          >
+            <a
+              href="#top"
+              className="text-[14px] font-semibold leading-[1.21em] text-black hover:opacity-50 transition-opacity inline-flex items-center gap-1"
+            >
+              <span aria-hidden>↑</span> Back to top
+            </a>
+          </div>
+        </div>
 
         {/* Divider — both mobile + desktop per updated Figma */}
         {/* Footer Section — shared component (also on home) */}

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -329,14 +329,26 @@ export default function ProjectPage({ params }: ProjectPageProps) {
                 </p>
               </div>
 
-              {/* Content column — Figma spec: Inter 18px / 28px line-height */}
+              {/* Content column — Figma spec: Inter 18px / 28px line-height.
+                  Review 2026-07-23: no space before the colon; comma-joined
+                  names render one per line, aligned under the first NAME
+                  (not the role) and without the commas — the flex row keeps
+                  the stacked names in their own column. */}
               <div className="flex-1">
                 <div className="text-[18px] leading-[28px]">
                   {project.credits.map((credit, index) => (
-                    <p key={index}>
-                      <span className="text-black">{credit.role}</span>
-                      <span className="text-black"> : </span>
-                      <span className="text-black">{credit.name}</span>
+                    <p key={index} className="flex">
+                      <span className="shrink-0 text-black">
+                        {credit.role}:&nbsp;
+                      </span>
+                      <span className="text-black">
+                        {credit.name.split(", ").map((name, i) => (
+                          <Fragment key={i}>
+                            {i > 0 && <br />}
+                            {name}
+                          </Fragment>
+                        ))}
+                      </span>
                     </p>
                   ))}
                 </div>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,4 +1,5 @@
 import { WorkGalleryItem } from "@/components/home";
+import { SiteFooter } from "@/components/layout";
 import { featuredProjects } from "@/config/site";
 import type { Metadata } from "next";
 
@@ -20,6 +21,12 @@ export default function WorkPage() {
       {projects.map((project) => (
         <WorkGalleryItem key={project.id} project={project} />
       ))}
+
+      {/* Footer per review 2026-07-23 ("eu deixaria no WORK") — desktop-only,
+          same treatment as home: mobile ends on the last full-bleed tile. */}
+      <div className="hidden md:block">
+        <SiteFooter />
+      </div>
     </>
   );
 }

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -1378,6 +1378,7 @@ export const projects: ProjectDetail[] = [
     year: "2024",
 
     credits: [
+      { role: "Group Creative Director", name: "Matt Brooke" },
       { role: "Art Director", name: "Vitor Milito" },
       { role: "CD Copy", name: "Jessica Clark" },
       { role: "Photographers", name: "Sebastian Sabal-Bruce, Luke Kuisis" },


### PR DESCRIPTION
Vitor's credits/footer batch (2026-07-23):

**Credits (all project pages)**
- "Creative Director : Name" → "Creative Director: Name" — no space before the colon.
- Comma-joined names now render one per line, no commas, and the stack aligns under the first **name**, not the role (flex row: role label is its own non-shrinking cell):
  ```
  Photographers: Fernando Tomaz
                 Hugo Toni
                 Marcio Scavone
                 Alex Korolkovas
  ```
  Applies to all 9 multi-name credits (YSL talent, Bride photographers/stylists/models, Ouronyx directors/talent, BFJ photographers, SK-II talent).
- Position: no change needed — the Credits label already starts exactly at the page's horizontal middle on desktop (the back-to-top column owns the left half), matching "começando na metade do banner".

**Footers**
- Contact page: "Reach out via contact@… at any time." starts on its own line.
- Home footer is now **desktop-only** ("só no mobile que achei estranho") — mobile home ends on the last tile.
- **/work** gains the same desktop-only footer ("eu deixaria no WORK").
- Project pages unchanged (footer on both breakpoints, as before).

Gates green (tsc, eslint, jest 274/274, pipefail on).