### PR TITLE
fix(wao-cosmo): drop "Showcase" from the project title

### DIFF
--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -531,7 +531,7 @@ export const projects: ProjectDetail[] = [
     id: "wao-cosmo",
     slug: "wao-cosmo",
     client: "Wao Cosmo",
-    title: "WAOMAG Showcase",
+    title: "WAOMAG",
     subtitle: "Creative Direction",
     headerTheme: "light",
     description:


### PR DESCRIPTION
Vitor (WhatsApp 2026-07-27, 21:06): "Acho que não precisa da palavra Showcase."

- `title: "WAOMAG Showcase"` → `"WAOMAG"` in `src/config/projects.ts` — the H1 on `/work/wao-cosmo` now matches the home/WORK tile name.
- `metaTitle` was already bare `"WAOMAG"`, so the browser tab (`WAOMAG | STUDIO HAUS`) is unchanged.

Gates: tsc, eslint, jest (274 passing).