### PR TITLE
fix(video): start clips only when they enter the viewport

### DIFF
--- a/src/__tests__/components/ui/GalleryGrid.test.tsx
+++ b/src/__tests__/components/ui/GalleryGrid.test.tsx
@@ -272,6 +272,7 @@ describe("GalleryGrid", () => {
         unobserve = jest.fn();
         disconnect = jest.fn();
       }
+      const prevIO = globalThis.IntersectionObserver;
       (globalThis as Record<string, unknown>).IntersectionObserver = MockIO;
       try {
         const { container } = render(
@@ -288,7 +289,54 @@ describe("GalleryGrid", () => {
         });
         expect(video.muted).toBe(true);
       } finally {
-        delete (globalThis as Record<string, unknown>).IntersectionObserver;
+        (globalThis as Record<string, unknown>).IntersectionObserver = prevIO;
+      }
+    });
+
+    it("scroll-gates playback: no autoplay, plays on enter, pauses on exit", () => {
+      // Element-matched capture — find the observer watching the video node
+      // (the audio hook registers observers of its own).
+      const observed: Array<[Element, IntersectionObserverCallback]> = [];
+      class MockIO {
+        private cb: IntersectionObserverCallback;
+        constructor(cb: IntersectionObserverCallback) {
+          this.cb = cb;
+        }
+        observe = (el: Element) => {
+          observed.push([el, this.cb]);
+        };
+        unobserve = jest.fn();
+        disconnect = jest.fn();
+      }
+      const prevIO = globalThis.IntersectionObserver;
+      (globalThis as Record<string, unknown>).IntersectionObserver = MockIO;
+      try {
+        const { container } = render(<GalleryGrid media={[makeVideo(1)]} />);
+        const video = container.querySelector("video")!;
+        expect(video).not.toHaveAttribute("autoplay");
+
+        const pair = observed.find(([el]) => el === video);
+        expect(pair).toBeDefined();
+
+        video.play = jest.fn().mockResolvedValue(undefined);
+        video.pause = jest.fn();
+        act(() => {
+          pair![1](
+            [{ isIntersecting: true } as IntersectionObserverEntry],
+            {} as IntersectionObserver,
+          );
+        });
+        expect(video.play).toHaveBeenCalled();
+
+        act(() => {
+          pair![1](
+            [{ isIntersecting: false } as IntersectionObserverEntry],
+            {} as IntersectionObserver,
+          );
+        });
+        expect(video.pause).toHaveBeenCalled();
+      } finally {
+        (globalThis as Record<string, unknown>).IntersectionObserver = prevIO;
       }
     });
 

--- a/src/__tests__/components/ui/HeroVideo.test.tsx
+++ b/src/__tests__/components/ui/HeroVideo.test.tsx
@@ -86,6 +86,54 @@ describe("HeroVideo", () => {
     );
   });
 
+  it("scroll-gates playback: no autoplay, plays on enter, pauses on exit", () => {
+    // Element-matched capture — find the observer watching the video node
+    // (the audio hook registers observers of its own).
+    const observed: Array<[Element, IntersectionObserverCallback]> = [];
+    class MockIO {
+      private cb: IntersectionObserverCallback;
+      constructor(cb: IntersectionObserverCallback) {
+        this.cb = cb;
+      }
+      observe = (el: Element) => {
+        observed.push([el, this.cb]);
+      };
+      unobserve = jest.fn();
+      disconnect = jest.fn();
+    }
+    const prevIO = globalThis.IntersectionObserver;
+    (globalThis as Record<string, unknown>).IntersectionObserver = MockIO;
+    try {
+      mockMatchMedia(false);
+      const { container } = render(<HeroVideo desktop="/d.mp4" />);
+      const video = container.querySelector("video")!;
+      expect(video).not.toHaveAttribute("autoplay");
+
+      const pair = observed.find(([el]) => el === video);
+      expect(pair).toBeDefined();
+
+      video.play = jest.fn().mockResolvedValue(undefined);
+      video.pause = jest.fn();
+      act(() => {
+        pair![1](
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+      expect(video.play).toHaveBeenCalled();
+
+      act(() => {
+        pair![1](
+          [{ isIntersecting: false } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+      expect(video.pause).toHaveBeenCalled();
+    } finally {
+      (globalThis as Record<string, unknown>).IntersectionObserver = prevIO;
+    }
+  });
+
   it("swaps the source when the viewport crosses the breakpoint", () => {
     const media = mockMatchMedia(false);
     const { container } = render(

--- a/src/__tests__/hooks/useInViewPlayback.test.tsx
+++ b/src/__tests__/hooks/useInViewPlayback.test.tsx
@@ -1,0 +1,108 @@
+import React, { useRef } from "react";
+import { render, act } from "@testing-library/react";
+import { useInViewPlayback } from "@/hooks/useInViewPlayback";
+
+// Capture the observer callback so tests can trigger intersections manually
+let observerCallback: IntersectionObserverCallback;
+const mockObserve = jest.fn();
+const mockDisconnect = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  observerCallback = undefined as unknown as IntersectionObserverCallback;
+
+  global.IntersectionObserver = jest.fn((callback) => {
+    observerCallback = callback;
+    return {
+      observe: mockObserve,
+      unobserve: jest.fn(),
+      disconnect: mockDisconnect,
+      root: null,
+      rootMargin: "",
+      thresholds: [],
+      takeRecords: jest.fn(),
+    };
+  }) as unknown as typeof IntersectionObserver;
+});
+
+// Helper component that attaches the hook to a real <video> element
+function Clip({ resyncKey }: { resyncKey?: unknown }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  useInViewPlayback(videoRef, resyncKey);
+  return <video ref={videoRef} data-testid="clip" muted />;
+}
+
+function triggerIntersection(isIntersecting: boolean) {
+  act(() => {
+    observerCallback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  });
+}
+
+describe("useInViewPlayback", () => {
+  it("observes the video element and does not play it on mount", () => {
+    const { getByTestId } = render(<Clip />);
+    const video = getByTestId("clip") as HTMLVideoElement;
+
+    expect(mockObserve).toHaveBeenCalledWith(video);
+    expect(video).not.toHaveAttribute("autoplay");
+  });
+
+  it("plays when the clip enters the viewport", () => {
+    const { getByTestId } = render(<Clip />);
+    const video = getByTestId("clip") as HTMLVideoElement;
+    video.play = jest.fn().mockResolvedValue(undefined);
+    video.pause = jest.fn();
+
+    triggerIntersection(true);
+
+    expect(video.play).toHaveBeenCalled();
+    expect(video.pause).not.toHaveBeenCalled();
+  });
+
+  it("pauses when the clip fully leaves the viewport", () => {
+    const { getByTestId } = render(<Clip />);
+    const video = getByTestId("clip") as HTMLVideoElement;
+    video.play = jest.fn().mockResolvedValue(undefined);
+    video.pause = jest.fn();
+
+    triggerIntersection(true);
+    triggerIntersection(false);
+
+    expect(video.pause).toHaveBeenCalled();
+  });
+
+  it("re-attaches the observer when resyncKey changes (breakpoint remount)", () => {
+    const { rerender } = render(<Clip resyncKey="/a.mp4" />);
+    expect(mockObserve).toHaveBeenCalledTimes(1);
+
+    rerender(<Clip resyncKey="/b.mp4" />);
+
+    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockObserve).toHaveBeenCalledTimes(2);
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = render(<Clip />);
+    unmount();
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("falls back to playing immediately when IntersectionObserver is unavailable", () => {
+    const prevIO = globalThis.IntersectionObserver;
+    delete (globalThis as Record<string, unknown>).IntersectionObserver;
+    const playSpy = jest
+      .spyOn(window.HTMLMediaElement.prototype, "play")
+      .mockResolvedValue(undefined);
+    try {
+      render(<Clip />);
+      expect(playSpy).toHaveBeenCalled();
+    } finally {
+      playSpy.mockRestore();
+      (globalThis as Record<string, unknown>).IntersectionObserver = prevIO;
+    }
+  });
+});

--- a/src/components/ui/GalleryVideo.tsx
+++ b/src/components/ui/GalleryVideo.tsx
@@ -6,6 +6,7 @@ import {
   useResponsiveVideoSource,
 } from "@/hooks/useMediaQuery";
 import { useExclusiveAudio } from "@/hooks/useExclusiveAudio";
+import { useInViewPlayback } from "@/hooks/useInViewPlayback";
 import { AudioToggleButton } from "./AudioToggleButton";
 
 interface GalleryVideoProps {
@@ -22,7 +23,11 @@ interface GalleryVideoProps {
  * time, so the native two-source markup (kept for SSR/no-JS) never swaps on
  * resize by itself.
  *
- * Clips flagged `hasAudio` get the Instagram-style treatment: they autoplay
+ * Playback is scroll-gated (useInViewPlayback): a clip starts from frame 0
+ * when it enters the viewport instead of autoplaying at page load already
+ * mid-film, and pauses/resumes as it leaves and re-enters.
+ *
+ * Clips flagged `hasAudio` get the Instagram-style treatment: they play
  * muted (autoplay policy) with a corner speaker button; clicking the video or
  * the button unmutes it and mutes every other clip on the page.
  */
@@ -39,6 +44,7 @@ export function GalleryVideo({ item, index }: GalleryVideoProps) {
         : !!item.hasAudio.desktop
       : !!item.hasAudio;
   const { videoRef, audible, toggle } = useExclusiveAudio(hasAudio, resolved);
+  useInViewPlayback(videoRef, resolved);
 
   const video = (
     <video
@@ -50,7 +56,6 @@ export function GalleryVideo({ item, index }: GalleryVideoProps) {
           : "w-full h-auto block"
       }${hasAudio ? " cursor-pointer" : ""}`}
       playsInline
-      autoPlay
       loop
       muted
       poster={item.inset ? undefined : item.poster}

--- a/src/components/ui/HeroVideo.tsx
+++ b/src/components/ui/HeroVideo.tsx
@@ -5,6 +5,7 @@ import {
   useResponsiveVideoSource,
 } from "@/hooks/useMediaQuery";
 import { useExclusiveAudio } from "@/hooks/useExclusiveAudio";
+import { useInViewPlayback } from "@/hooks/useInViewPlayback";
 import { AudioToggleButton } from "./AudioToggleButton";
 
 interface HeroVideoProps {
@@ -44,6 +45,12 @@ interface HeroVideoProps {
  *
  * When only one side has a file, the other side renders nothing — the page
  * supplies its own fallback (e.g. the static heroImage on desktop).
+ *
+ * Playback is scroll-gated (useInViewPlayback). The project-page hero sits
+ * at the top and is in view on load, so it still starts right away — but on
+ * the home page, where the same component layers each tile's banner, a tile
+ * below the fold now starts from frame 0 when scrolled to instead of already
+ * being mid-film.
  */
 export function HeroVideo({
   desktop,
@@ -84,6 +91,7 @@ export function HeroVideo({
     audioEnabled,
     resolved,
   );
+  useInViewPlayback(videoRef, resolved);
 
   if (!desktop && !mobile) return null;
   // Breakpoint known but this side has no file (e.g. desktop viewport on a
@@ -97,7 +105,6 @@ export function HeroVideo({
       className={`absolute inset-0 w-full h-full${audioEnabled ? " cursor-pointer" : ""}`}
       style={{ objectFit, objectPosition }}
       playsInline
-      autoPlay
       loop
       muted
       poster={activePoster}

--- a/src/hooks/useInViewPlayback.ts
+++ b/src/hooks/useInViewPlayback.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Scroll-gated playback for the muted looping clips: play while any part of
+ * the element is in the viewport, pause once it fully leaves. The <video>
+ * must NOT carry the autoPlay attribute — playback starts here instead, so a
+ * clip entering view for the first time starts at frame 0 rather than
+ * already being mid-film (client note 2026-07-27), and re-entries resume
+ * where they paused, Instagram-style.
+ *
+ * Pass the resolved source as `resyncKey`: the breakpoint swap remounts the
+ * video element (key), and the effect re-attaches the observer to the new
+ * node. Browsers without IntersectionObserver fall back to playing
+ * immediately (the old autoplay behavior) so clips never dead-end.
+ */
+export function useInViewPlayback(
+  videoRef: RefObject<HTMLVideoElement | null>,
+  resyncKey?: unknown,
+) {
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (typeof IntersectionObserver === "undefined") {
+      v.play()?.catch(() => {});
+      return;
+    }
+    const io = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) v.play()?.catch(() => {});
+      else v.pause();
+    });
+    io.observe(v);
+    return () => io.disconnect();
+  }, [videoRef, resyncKey]);
+}


### PR DESCRIPTION
Vitor (WhatsApp 2026-07-27): *"Esse vídeo quando cheguei na essa parte já estava no meio do filme"* — the WAO street-style clip was mid-film by the time he scrolled to it, because every `<video>` carried the `autoPlay` attribute and started at page load.

## Change
- New `useInViewPlayback` hook: an IntersectionObserver **plays** a clip when any part of it enters the viewport and **pauses** it when it fully leaves. First entry always starts at frame 0; re-entries resume where they paused (Instagram model — consistent with the audio buttons).
- `autoPlay` removed from `GalleryVideo` (all in-gallery clips) and `HeroVideo` (project heroes + home tile banners).
- Project-page heroes sit at the top and are in view at load, so they still start immediately. Home tiles below the fold now start from 0 when scrolled to — same complaint, also fixed.
- Browsers without IntersectionObserver fall back to playing immediately (old behavior).
- Side benefit: off-screen clips no longer decode — WAO had ~11 videos playing simultaneously; on phones this is a real battery/CPU win.

## Watch-point
Framed cards whose poster is suppressed (Ouronyx inset slots) used to be pre-loaded by autoplay; now they fetch on first entry, so on slow connections there can be a brief blank before the first frame. If Vitor flags it, next iteration is a look-ahead preload one viewport before entry.

## Tests
6-case unit suite for the hook + scroll-gating integration tests in GalleryGrid and HeroVideo suites (282 passing). tsc + eslint clean.