### PR TITLE
fix(typography): review line-break fixes + About font size

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -26,12 +26,14 @@ export default function About() {
           <div className="flex-1">
             {/* Copy per the TEXTO PARA SITE update (2026-07-23) — heading is
                 "About Us", not "About Studio Haus", per Vitor's note. */}
-            {/* Section labels scale with the body copy (15/19) — at 14px they
-                read undersized against the 19px paragraphs (review 2026-07-23). */}
-            <h1 className="text-[15px] md:text-[19px] font-bold uppercase leading-[1.21em] text-black mb-[23px] md:mb-[58px]">
+            {/* Section labels scale with the body copy (15/16) — at 14px they
+                read undersized against the paragraphs (review 2026-07-23).
+                Desktop body 19→16 per review 2026-07-27 ("menor que essa mas
+                maior que" the 14px case descriptions). */}
+            <h1 className="text-[15px] md:text-[16px] font-bold uppercase leading-[1.21em] text-black mb-[23px] md:mb-[58px]">
               About Us
             </h1>
-            <div className="md:pl-[4px] space-y-6 text-[15px] leading-[1.21em] md:text-[19px] md:leading-[1.68em] max-w-[750px]">
+            <div className="md:pl-[4px] space-y-6 text-[15px] leading-[1.21em] md:text-[16px] md:leading-[1.68em] max-w-[750px]">
               <p>
                 Studio Haus Creative is an independent creative consultancy specialising in luxury branding, image-making and global campaign direction.
               </p>
@@ -74,7 +76,7 @@ export default function About() {
           {/* Contact section — visible on both breakpoints per Figma
               About-D (in left column under body text). */}
           <div className="mt-16 md:mt-20 pb-8 md:pl-[9px]">
-            <h2 className="text-[15px] md:text-[19px] font-bold uppercase leading-[1.21em] text-black mb-[37px]">
+            <h2 className="text-[15px] md:text-[16px] font-bold uppercase leading-[1.21em] text-black mb-[37px]">
               Contact
             </h2>
             <div className="space-y-[19px] text-[15px] leading-[1.21em]">

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -376,7 +376,7 @@ export const projects: ProjectDetail[] = [
     introText: [
       "YSL Beauty's first global Eid campaign marked a milestone for the luxury house, celebrating one of the region's most important cultural moments through a contemporary lens.",
       "Inspired by the warmth and cinematic beauty of desert sunsets, I collaborated with YSL Beauty's global and regional teams to develop the creative direction for a series of capsule films featuring brand ambassadors from the GCC and Southeast Asia.",
-      "The challenge was to honour local cultural nuances while remaining unmistakably YSL, balancing authenticity with the brand's iconic visual codes. The result was a refined campaign that connected with regional audiences while maintaining a cohesive global identity.",
+      "The challenge was to honour local cultural nuances while remaining unmistakably YSL, balancing authenticity with the brand's iconic visual codes. The result was a refined campaign that connected with regional audiences while maintaining a cohesive global\u00A0identity.",
     ],
 
     // Both Figma frames tag the hero as video. The delivered
@@ -1262,7 +1262,7 @@ export const projects: ProjectDetail[] = [
     introText: [
       "The Summer of Indulgence was a 360° campaign celebrating the pleasures of the season while showcasing Bucherer's jewellery, watches and luxury retail experience.",
       "Inspired by the warmth and joy of summer, we developed a vibrant creative concept built around colourful visuals, playful copy and nostalgic ice cream references. Bucherer boutiques were transformed into luxurious gelaterias, inviting customers to indulge in scoops of flavour while discovering the latest collections.",
-      "The campaign unified multiple retail offerings under a single creative platform, delivering a cohesive brand experience across advertising, retail, digital and social media.",
+      "The campaign unified multiple retail offerings under a single creative platform, delivering a cohesive brand experience across advertising, retail, digital and social\u00A0media.",
     ],
 
     heroImage: {
@@ -1361,11 +1361,11 @@ export const projects: ProjectDetail[] = [
     location: "Shot in Cape Town, South Africa",
     agency: "Spring Studios",
     introText: [
-      "Spring Studios was commissioned to develop a comprehensive content strategy for Bucherer Fine Jewellery, creating distinct visual worlds for each collection.",
+      "Spring Studios was commissioned to develop a comprehensive content strategy for Bucherer Fine Jewellery, creating distinct visual worlds for each\u00A0collection.",
       // "we\u00A0developed" sends "we" down off the desktop first line;
       // "e-\u2060commerce" (word joiner) never splits after the "e-"
       // (review 2026-07-27).
-      "From the bohemian spirit of Peekaboo to the understated minimalism of B Dimension, we\u00A0developed eight unique personas, defined by their own lifestyle and attitude.",
+      "From the bohemian spirit of Peekaboo to the understated minimalism of B Dimension, we\u00A0developed eight unique personas, defined by their own lifestyle and\u00A0attitude.",
       "Across multiple locations, we produced editorial photography, still life and film that brought each collection to life. The resulting assets were deployed across digital campaigns, e-\u2060commerce, social media, DOOH, print collateral and in-store experiences, establishing a cohesive visual language across every customer touchpoint.",
     ],
 
@@ -1515,7 +1515,7 @@ export const projects: ProjectDetail[] = [
     agency: "Spring Studios",
     introText: [
       "Beauty Has Power was the launch campaign for OURONYX, a next-generation aesthetic wellness brand, created to build awareness and drive conversion across key international markets.",
-      "From the outset, I helped shape the brand's creative vision, from naming, visual identity and clinic interiors to the art direction of the launch campaign. We developed a sophisticated visual language featuring premium talent that reflected the brand's international audience and positioning.",
+      "From the outset, I helped shape the brand's creative vision, from naming, visual identity and clinic interiors to the art direction of the launch campaign. We developed a sophisticated visual language featuring premium talent that reflected the brand's international audience and\u00A0positioning.",
       "Beyond the campaign, the project encompassed a complete digital ecosystem, including doctor-led video content, an immersive website with interactive features and an integrated booking platform, alongside a comprehensive social media programme supporting both launch and ongoing brand growth.",
     ],
 
@@ -1767,7 +1767,7 @@ export const projects: ProjectDetail[] = [
     editorialSubtitle: "Creative Direction",
     location: "São Paulo, Brazil",
     introText: [
-      "As Creative Director of BRIDE, São Paulo's leading trade fair for the luxury wedding industry, I expanded the brand beyond the annual event into a multi-platform business.",
+      "As Creative Director of BRIDE, São Paulo's leading trade fair for the luxury wedding industry, I expanded the brand beyond the annual event into a multi-platform\u00A0business.",
       "I conceived and launched BRIDE Magazine, leading its editorial vision while developing the publication's branding and design system. I oversaw creative direction across content, design and production, while building strategic partnerships with brands, photographers, designers and industry collaborators.",
       "Under this expanded vision, BRIDE also evolved into a creative agency, delivering branding, editorial and design projects for clients across the luxury wedding ecosystem. The result was a cohesive brand platform that extended BRIDE's influence beyond the event, establishing it as a year-round creative and editorial authority within the industry.",
     ],

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -241,7 +241,10 @@ export const projects: ProjectDetail[] = [
     // Client copy 2026-07-20 — the text lists no agency for this project
     // (the earlier "ITP Media" line was dropped with it).
     introText: [
-      "Commissioned for Marie Claire Arabia's September issue, this editorial reimagined back-to-office dressing through a contemporary fashion perspective.",
+      // \u2060 (word joiner) after each hyphen keeps "back-to-office"
+      // whole at any line end (review 2026-07-27); the SEO description
+      // above stays free of control characters.
+      "Commissioned for Marie Claire Arabia's September issue, this editorial reimagined back-\u2060to-\u2060office dressing through a contemporary fashion perspective.",
       "Shot across the streets of Central London, the story portrays the modern executive woman: confident, ambitious and effortlessly elegant. Combining cinematic urban imagery with refined editorial styling.",
     ],
     editorialSubtitle: "Creative Direction",
@@ -761,8 +764,10 @@ export const projects: ProjectDetail[] = [
     location: "São Paulo, Brazil",
     agency: "GB65",
     introText: [
-      "For over a decade, Gisele Bündchen has been the face of Vivara, appearing in four major campaigns each year. The creative challenge is continually reinventing the visual narrative while preserving the strength and recognition of such an enduring partnership.",
-      "Working under the creative direction of Giovanni Bianco, I contributed to campaigns that refreshed the brand's aesthetic season after season, balancing timeless elegance with contemporary luxury to keep each collection feeling distinctive and relevant.",
+      // \u00A0 bindings: "The" and "I" sat stranded at mobile line ends
+      // (review 2026-07-27) — each wraps together with its next word.
+      "For over a decade, Gisele Bündchen has been the face of Vivara, appearing in four major campaigns each year. The\u00A0creative challenge is continually reinventing the visual narrative while preserving the strength and recognition of such an enduring partnership.",
+      "Working under the creative direction of Giovanni Bianco, I\u00A0contributed to campaigns that refreshed the brand's aesthetic season after season, balancing timeless elegance with contemporary luxury to keep each collection feeling distinctive and relevant.",
     ],
 
     heroVideo: {
@@ -1357,8 +1362,11 @@ export const projects: ProjectDetail[] = [
     agency: "Spring Studios",
     introText: [
       "Spring Studios was commissioned to develop a comprehensive content strategy for Bucherer Fine Jewellery, creating distinct visual worlds for each collection.",
-      "From the bohemian spirit of Peekaboo to the understated minimalism of B Dimension, we developed eight unique personas, defined by their own lifestyle and attitude.",
-      "Across multiple locations, we produced editorial photography, still life and film that brought each collection to life. The resulting assets were deployed across digital campaigns, e-commerce, social media, DOOH, print collateral and in-store experiences, establishing a cohesive visual language across every customer touchpoint.",
+      // "we\u00A0developed" sends "we" down off the desktop first line;
+      // "e-\u2060commerce" (word joiner) never splits after the "e-"
+      // (review 2026-07-27).
+      "From the bohemian spirit of Peekaboo to the understated minimalism of B Dimension, we\u00A0developed eight unique personas, defined by their own lifestyle and attitude.",
+      "Across multiple locations, we produced editorial photography, still life and film that brought each collection to life. The resulting assets were deployed across digital campaigns, e-\u2060commerce, social media, DOOH, print collateral and in-store experiences, establishing a cohesive visual language across every customer touchpoint.",
     ],
 
     heroVideo: {


### PR DESCRIPTION
Closes #76. **Stacked on #83** (copy-edits) — the Bucherer bindings apply to the post-deletion text; merge #83 first, then retarget/merge this.

Technique: invisible line-break controls as **visible `\u` escapes** in the config strings (greppable, no markup, SEO `description` strings stay clean):

- `⁠` (word joiner) after a hyphen = no break at that hyphen → **MC Arabia** "back-⁠to-⁠office" wraps whole; **Bucherer** "e-commerce" never splits after "e-"
- ` ` (no-break space) between words = they wrap as a unit → **Bucherer** "we developed" ("we" leaves the desktop first line), **Vivara** "The creative" / "I contributed" (mobile rag)

**About page**: desktop body 19px → 16px (between the old 19 and the 14px case descriptions, per the review note); section labels (About Us / Contact) follow per the 2026-07-23 "labels scale with body" rule. Mobile stays 15px.

Please eyeball the rag on the Vercel preview at both breakpoints — line-break fixes are viewport-sensitive by nature.

Gate: tsc ✓ · lint ✓ · jest 282/282 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)