### PR TITLE
feat(video): look-ahead prefetch — buffer clips one viewport before they enter

### DIFF
--- a/docs/CHANGELOG-2026-07-28.md
+++ b/docs/CHANGELOG-2026-07-28.md
@@ -26,9 +26,11 @@ do review para o Vitor conferir item a item. PRs: #83 (copy), #86 (tipografia),
 
 - ✅ **Marie Claire** — novo `MC_MOB_01` (versão 27/07, masthead centralizado) no hero mobile.
 
-## Ainda aberto (não entrou neste deploy)
+## Vídeos
 
-- ⏳ **Harrods** — vídeo do par (cena do jantar) não tocando no desktop — em investigação ([#77](https://github.com/RafaelMurad/haus-creative/issues/77)).
+- ✅ **Harrods (e todos os vídeos do site)** — o vídeo do jantar que "não tocava" no desktop: o clipe só começava a baixar quando entrava na tela (7,5 MB na hora = poster parado). Agora todo vídeo pré-carrega **uma tela antes** de aparecer — chega no viewport já com buffer e toca na hora, do frame 0 ([#77](https://github.com/RafaelMurad/haus-creative/issues/77)).
+
+## Ainda aberto (não entrou neste deploy)
 - ⏳ **Ouronyx 10/11** — esperando os re-exports com áudio do Diego ([#79](https://github.com/RafaelMurad/haus-creative/issues/79)).
 - ⏳ **Domínio** — esperando login do cPanel ([#80](https://github.com/RafaelMurad/haus-creative/issues/80)).
 - ⏳ **Showreel** — esperando o edit ([#81](https://github.com/RafaelMurad/haus-creative/issues/81)).

--- a/docs/REVIEW-2026-07-27.md
+++ b/docs/REVIEW-2026-07-27.md
@@ -44,7 +44,7 @@ attachments 00000102–00000121, sent 27/07 19:31–19:47.
 
 ## C. Bug — [#77](https://github.com/RafaelMurad/haus-creative/issues/77)
 
-- [ ] **C1. Harrods (desktop)** — left video of the dining + still-life pair
+- [x] **C1. Harrods (desktop)** — left video of the dining + still-life pair
       not playing (screenshot 19:32). Investigate desktop playback gating.
 
 ## D. Assets — [#78](https://github.com/RafaelMurad/haus-creative/issues/78)

--- a/src/__tests__/hooks/useInViewPlayback.test.tsx
+++ b/src/__tests__/hooks/useInViewPlayback.test.tsx
@@ -2,39 +2,56 @@ import React, { useRef } from "react";
 import { render, act } from "@testing-library/react";
 import { useInViewPlayback } from "@/hooks/useInViewPlayback";
 
-// Capture the observer callback so tests can trigger intersections manually
-let observerCallback: IntersectionObserverCallback;
-const mockObserve = jest.fn();
-const mockDisconnect = jest.fn();
+// The hook creates TWO observers per element: the playback gate (no
+// rootMargin) and the look-ahead prefetch (rootMargin one viewport out).
+// Track every instance with its options so tests can address each.
+interface MockObserver {
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  observe: jest.Mock;
+  disconnect: jest.Mock;
+}
+let observers: MockObserver[] = [];
 
 beforeEach(() => {
   jest.clearAllMocks();
-  observerCallback = undefined as unknown as IntersectionObserverCallback;
+  observers = [];
 
-  global.IntersectionObserver = jest.fn((callback) => {
-    observerCallback = callback;
-    return {
-      observe: mockObserve,
-      unobserve: jest.fn(),
-      disconnect: mockDisconnect,
-      root: null,
-      rootMargin: "",
-      thresholds: [],
-      takeRecords: jest.fn(),
-    };
-  }) as unknown as typeof IntersectionObserver;
+  global.IntersectionObserver = jest.fn(
+    (callback: IntersectionObserverCallback, options?: IntersectionObserverInit) => {
+      const instance: MockObserver = {
+        callback,
+        options,
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+      };
+      observers.push(instance);
+      return {
+        observe: instance.observe,
+        unobserve: jest.fn(),
+        disconnect: instance.disconnect,
+        root: null,
+        rootMargin: options?.rootMargin ?? "",
+        thresholds: [],
+        takeRecords: jest.fn(),
+      };
+    },
+  ) as unknown as typeof IntersectionObserver;
 });
+
+const playbackObservers = () => observers.filter((o) => !o.options?.rootMargin);
+const prefetchObservers = () => observers.filter((o) => o.options?.rootMargin);
 
 // Helper component that attaches the hook to a real <video> element
 function Clip({ resyncKey }: { resyncKey?: unknown }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   useInViewPlayback(videoRef, resyncKey);
-  return <video ref={videoRef} data-testid="clip" muted />;
+  return <video ref={videoRef} data-testid="clip" muted preload="none" />;
 }
 
-function triggerIntersection(isIntersecting: boolean) {
+function trigger(observer: MockObserver, isIntersecting: boolean) {
   act(() => {
-    observerCallback(
+    observer.callback(
       [{ isIntersecting } as IntersectionObserverEntry],
       {} as IntersectionObserver,
     );
@@ -46,7 +63,8 @@ describe("useInViewPlayback", () => {
     const { getByTestId } = render(<Clip />);
     const video = getByTestId("clip") as HTMLVideoElement;
 
-    expect(mockObserve).toHaveBeenCalledWith(video);
+    expect(playbackObservers()).toHaveLength(1);
+    expect(playbackObservers()[0].observe).toHaveBeenCalledWith(video);
     expect(video).not.toHaveAttribute("autoplay");
   });
 
@@ -56,7 +74,7 @@ describe("useInViewPlayback", () => {
     video.play = jest.fn().mockResolvedValue(undefined);
     video.pause = jest.fn();
 
-    triggerIntersection(true);
+    trigger(playbackObservers()[0], true);
 
     expect(video.play).toHaveBeenCalled();
     expect(video.pause).not.toHaveBeenCalled();
@@ -68,27 +86,28 @@ describe("useInViewPlayback", () => {
     video.play = jest.fn().mockResolvedValue(undefined);
     video.pause = jest.fn();
 
-    triggerIntersection(true);
-    triggerIntersection(false);
+    trigger(playbackObservers()[0], true);
+    trigger(playbackObservers()[0], false);
 
     expect(video.pause).toHaveBeenCalled();
   });
 
-  it("re-attaches the observer when resyncKey changes (breakpoint remount)", () => {
+  it("re-attaches the observers when resyncKey changes (breakpoint remount)", () => {
     const { rerender } = render(<Clip resyncKey="/a.mp4" />);
-    expect(mockObserve).toHaveBeenCalledTimes(1);
+    expect(playbackObservers()).toHaveLength(1);
 
     rerender(<Clip resyncKey="/b.mp4" />);
 
-    expect(mockDisconnect).toHaveBeenCalled();
-    expect(mockObserve).toHaveBeenCalledTimes(2);
+    expect(playbackObservers()[0].disconnect).toHaveBeenCalled();
+    expect(playbackObservers()).toHaveLength(2);
   });
 
-  it("disconnects the observer on unmount", () => {
+  it("disconnects both observers on unmount", () => {
     const { unmount } = render(<Clip />);
     unmount();
 
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(playbackObservers()[0].disconnect).toHaveBeenCalled();
+    expect(prefetchObservers()[0].disconnect).toHaveBeenCalled();
   });
 
   it("falls back to playing immediately when IntersectionObserver is unavailable", () => {
@@ -104,5 +123,45 @@ describe("useInViewPlayback", () => {
       playSpy.mockRestore();
       (globalThis as Record<string, unknown>).IntersectionObserver = prevIO;
     }
+  });
+
+  describe("look-ahead prefetch", () => {
+    it("registers a second observer with a one-viewport rootMargin", () => {
+      const { getByTestId } = render(<Clip />);
+      const video = getByTestId("clip") as HTMLVideoElement;
+
+      expect(prefetchObservers()).toHaveLength(1);
+      expect(prefetchObservers()[0].options?.rootMargin).toBe("100% 0px");
+      expect(prefetchObservers()[0].observe).toHaveBeenCalledWith(video);
+    });
+
+    it("upgrades preload to auto on approach WITHOUT playing", () => {
+      const { getByTestId } = render(<Clip />);
+      const video = getByTestId("clip") as HTMLVideoElement;
+      video.play = jest.fn().mockResolvedValue(undefined);
+
+      trigger(prefetchObservers()[0], true);
+
+      expect(video.preload).toBe("auto");
+      expect(video.play).not.toHaveBeenCalled();
+    });
+
+    it("is one-shot: disconnects after the first approach", () => {
+      render(<Clip />);
+
+      trigger(prefetchObservers()[0], true);
+
+      expect(prefetchObservers()[0].disconnect).toHaveBeenCalled();
+    });
+
+    it("does not upgrade preload while still out of prefetch range", () => {
+      const { getByTestId } = render(<Clip />);
+      const video = getByTestId("clip") as HTMLVideoElement;
+
+      trigger(prefetchObservers()[0], false);
+
+      expect(video.preload).toBe("none");
+      expect(prefetchObservers()[0].disconnect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/hooks/useInViewPlayback.ts
+++ b/src/hooks/useInViewPlayback.ts
@@ -31,6 +31,28 @@ export function useInViewPlayback(
       else v.pause();
     });
     io.observe(v);
-    return () => io.disconnect();
+
+    // Look-ahead prefetch: one viewport before the clip scrolls in, upgrade
+    // preload so the file buffers during the approach instead of at entry.
+    // Without this, a preload="none" clip fetches its first byte only when
+    // play() fires at the viewport edge — on a cold CDN region the visitor
+    // stares at the poster while megabytes stream in (Vitor's "video da
+    // esquerda não tá tocando", review 2026-07-27). One-shot per element;
+    // playback stays gated at the true boundary above, so the frame-0 rule
+    // is untouched.
+    const prefetch = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        v.preload = "auto";
+        prefetch.disconnect();
+      },
+      { rootMargin: "100% 0px" },
+    );
+    prefetch.observe(v);
+
+    return () => {
+      io.disconnect();
+      prefetch.disconnect();
+    };
   }, [videoRef, resyncKey]);
 }


### PR DESCRIPTION
Closes #77.

**Root cause of the "left video not playing" report:** it was never a playback bug — the code path is sound (verified: the clip plays instantly on localhost). PR #72 removed autoplay, which used to buffer every clip from page load; since then a `preload="none"` clip fetches its FIRST byte only when `play()` fires at the viewport edge. `harrods-video-5.mp4` is 7.5 MB — on a cold CDN region the visitor stares at the poster (which for this slot looks like a video frame) while it streams. That reads as "não tá tocando".

**Fix:** `useInViewPlayback` now attaches a second, one-shot IntersectionObserver with `rootMargin: "100% 0px"` — one viewport before a clip scrolls in, its `preload` upgrades to `"auto"` and buffering starts during the approach scroll. Playback stays gated at the true viewport boundary, so the client's frame-0 rule (PR #72) is untouched. Covers gallery clips, project heroes and home tiles (all use this hook).

Measured on the dev server (Harrods, the reported clip):

| scroll position | preload | buffered | playing |
|---|---|---|---|
| 2.2 viewports away | none | 0s | no |
| 1.5 viewports away | none | 0s | no |
| 0.5 viewport away (not yet visible) | auto | 14s | no (frame 0) |
| in view | auto | 14s | yes, from 0 |

Also implements recommendation #2 of the 2026-07-27 video serving assessment. Tests: 4 new prefetch cases; suite 286/286 ✓, tsc ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)