### PR TITLE
fix(harrods): dining clip plays on desktop too (slot 2)

### DIFF
--- a/docs/CHANGELOG-2026-07-28.md
+++ b/docs/CHANGELOG-2026-07-28.md
@@ -34,6 +34,8 @@ do review para o Vitor conferir item a item. PRs: #83 (copy), #86 (tipografia),
 
 - ✅ **Ouronyx** — os dois vídeos de entrevista (mulher + Daniel Ricciardo) substituídos pelos re-exports do Di: 720×900 com o áudio real da entrevista — botão de som ativo nos dois ([#79](https://github.com/RafaelMurad/haus-creative/issues/79)).
 
+- ✅ **Harrods** — o vídeo do jantar (par de cima) agora toca também no desktop, na mesma caixa da imagem (a foto vira o poster). Era o twin mobile-only da leitura antiga do pin no Figma.
+
 ## Ainda aberto (não entrou neste deploy)
 - ⏳ **Domínio** — esperando login do cPanel ([#80](https://github.com/RafaelMurad/haus-creative/issues/80)).
 - ⏳ **Showreel** — esperando o edit ([#81](https://github.com/RafaelMurad/haus-creative/issues/81)).

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -1958,12 +1958,18 @@ export const projects: ProjectDetail[] = [
         mobileOnly: true,
       },
       {
-        // Desktop half of the twin — static on desktop per the pin's
-        // mobile-only placement.
-        type: "image",
-        desktop: "/assets/harrods/harrods-2.webp",
-        mobile: "/assets/harrods/harrods-2-mobile.webp",
-        alt: "harrods image 1",
+        // Desktop half of the twin — now plays the clip here too (Vitor
+        // 2026-07-31: "esse video da esquerda continua como imagem apenas
+        // no desktop"; supersedes the mobile-only pin reading of PR #46).
+        // aspect (without inset) keeps the still's exact 720/1065 box: the
+        // 1080×2048 clip cover-fills it and the old still stays as poster,
+        // so the pair layout and first paint are unchanged.
+        type: "video",
+        desktop: "/assets/harrods/harrods-video-2.mp4",
+        hasAudio: true,
+        poster: "/assets/harrods/harrods-2.webp",
+        aspect: "720/1065",
+        alt: "harrods video 1",
         desktopOnly: true,
       },
       {


### PR DESCRIPTION
Vitor 2026-07-31: "esse video da esquerda continua como imagem apenas no desktop".

Root cause: PR #46 wired V1 mobile-only per the Figma tag rule (the pin sat on the mobile column only) — on desktop, slot 2 deliberately rendered the still. Vitor's message supersedes that reading: the desktop half of the twin is now the clip.

Implementation: the desktop slot keeps the still's exact `720/1065` box via `aspect` (no `inset`, so the still remains as poster) — the 1080×2048 clip cover-fills it. Verified at 1600×900: video cell and the harrods-3 partner card are pixel-identical boxes (889×1315, same top), clip plays scroll-gated with 15s buffered, speaker button present. Mobile is untouched (the approved full-span twin).

Also corrects the #77 record: Vitor's original 27/07 report was about THIS pair showing a still on desktop — not the video-5 card's buffering (the prefetch fix in #87 stands as a perf win regardless).

Gate: tsc ✓ · jest 286/286 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)