### PR TITLE
feat: work-page tile videos + contact copy updates (Vitor 2026-08-04)

### DIFF
--- a/src/__tests__/app/contact.test.tsx
+++ b/src/__tests__/app/contact.test.tsx
@@ -57,11 +57,11 @@ describe("Contact page", () => {
     });
   });
 
-  it("describes global operations with London and São Paulo hubs", () => {
+  it("describes global operations with London, Dubai and São Paulo hubs", () => {
     render(<ContactPage />);
 
     expect(
-      screen.getByText(/operate globally with hubs in london/i),
+      screen.getByText(/operate globally with hubs in london, dubai and são paulo/i),
     ).toBeInTheDocument();
   });
 });

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,7 +4,7 @@ import { siteConfig } from "@/config/site";
 export const metadata: Metadata = {
   title: "Contact",
   description:
-    "Get in touch with Studio Haus Creative. Operating globally with hubs in London and São Paulo for strategy, creative direction, design, production, and post-production.",
+    "Get in touch with Studio Haus Creative. Operating globally with hubs in London, Dubai and São Paulo for strategy, creative direction, design, production, and post-production.",
   alternates: {
     canonical: "/contact",
   },
@@ -49,7 +49,8 @@ export default function ContactPage() {
           </div>
           <div className="flex-1 md:max-w-[1115px]">
             <p className="text-[15px] leading-[1.53em] md:text-[18px] md:leading-[1.55em]">
-              We operate globally with hubs in London and São Paulo, building and scaling up bespoke teams to provide the best talent for each client. From strategy, creative direction, design through Production and Post Production. Get in touch to discuss how we can collaborate together.
+              {/* "London, Dubai and São Paulo" per Vitor 2026-08-04. */}
+              We operate globally with hubs in London, Dubai and São Paulo, building and scaling up bespoke teams to provide the best talent for each client. From strategy, creative direction, design through Production and Post Production. Get in touch to discuss how we can collaborate together.
             </p>
           </div>
         </div>
@@ -70,8 +71,8 @@ export default function ContactPage() {
           </div>
           <div className="flex-1 md:max-w-[1115px]">
             <p className="text-[15px] leading-[1.53em] md:text-[18px] md:leading-[1.55em]">
-              We are always looking to connect with creatives globally. We
-              operate hybrid in remote between London and São Paulo.
+              {/* "We operate hybrid in remote…" removed per Vitor 2026-08-04. */}
+              We are always looking to connect with creatives globally.
               {/* "Reach out via…" starts its own line (review 2026-07-23). */}
               <br />
               Reach out via{" "}

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,6 +1,7 @@
 import { WorkGalleryItem } from "@/components/home";
 import { SiteFooter } from "@/components/layout";
 import { featuredProjects } from "@/config/site";
+import { projects as projectDetails } from "@/config/projects";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -12,14 +13,23 @@ export const metadata: Metadata = {
   },
 };
 
+/** slug → project detail, for the tile hero videos (same lookup as home). */
+const projectBySlug = new Map(projectDetails.map((p) => [p.slug, p]));
+
 export default function WorkPage() {
   const [, ...projects] = featuredProjects;
 
   return (
     <>
-      {/* Work Gallery Items - Each navigable to its own page, like Home but without IntroHero */}
+      {/* Work Gallery Items - Each navigable to its own page, like Home but
+          without IntroHero. Tiles play the same hero videos as home since
+          2026-08-04 ("página work ainda está só com imagens não vídeos"). */}
       {projects.map((project) => (
-        <WorkGalleryItem key={project.id} project={project} />
+        <WorkGalleryItem
+          key={project.id}
+          project={project}
+          heroVideo={projectBySlug.get(project.id)?.heroVideo}
+        />
       ))}
 
       {/* Footer per review 2026-07-23 ("eu deixaria no WORK") — desktop-only,


### PR DESCRIPTION
Three asks from the 2026-08-04 batch:

1. **/work tiles play the hero videos** — same files and lookup as home (`projectBySlug.get(id)?.heroVideo` → `WorkGalleryItem`); scroll-gating, prefetch and the warm queue all apply since it's the same `HeroVideo` path. MC Arabia stays static (its hero video was retired 2026-07-20 by review).
2. **New Business**: "hubs in London, **Dubai** and São Paulo" (+ SEO description aligned; contact test assertion tightened to the new copy).
3. **For Talent**: removed "We operate hybrid in remote between London and São Paulo."

Verified on dev: 7 tile videos SSR'd on /work, new copy renders, "hybrid in remote" gone. Gate: tsc ✓ jest 287/287 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)