### PR TITLE
docs: Ouronyx mockup card — no audio, on the list

### DIFF
--- a/docs/CLIENT-ASKS.md
+++ b/docs/CLIENT-ASKS.md
@@ -108,6 +108,12 @@ No action needed if silence is intentional (likely for the UI mockups).
 interview mixes — wired to slots 16/17 with the audio toggle. Still silent:
 WEB 2/3/5 + MOBILE 2/3/9 (UI mockup cards; presumed intentional).
 
+**Update 2026-08-04 (Vitor, WhatsApp):** confirmed for the laptop+phone
+site-mockup card ("Beauty Has Power" hero) — **no audio needed**, silence is
+intentional; keep it on the re-export list, no urgency ("não precisa ser
+agora, só deixa na lista"). When Diego's hi-res re-export of that card
+arrives (#5), wire it silent — no `hasAudio` flag.
+
 ## ~~3. Ouronyx — two gallery images never delivered~~ RESOLVED 2026-07-10
 
 Rafael exported the two missing pair-partner stills from Figma directly


### PR DESCRIPTION
Backlog annotation from Vitor (2026-08-04): the laptop+phone site-mockup card needs no audio when its hi-res re-export arrives (CLIENT-ASKS #5/#7 updated). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)