### PR TITLE
docs: MOBILE 9 audio re-export confirmed ask

### DIFF
--- a/docs/CLIENT-ASKS.md
+++ b/docs/CLIENT-ASKS.md
@@ -108,6 +108,14 @@ No action needed if silence is intentional (likely for the UI mockups).
 interview mixes — wired to slots 16/17 with the audio toggle. Still silent:
 WEB 2/3/5 + MOBILE 2/3/9 (UI mockup cards; presumed intentional).
 
+**Update 2026-08-05 — MOBILE 9 CONFIRMED ASK:** Vitor flagged the doctors'
+interview on mobile ("os médicos da Ouronyx no mobile (último vídeo) está sem
+áudio"). The MOBILE 9 export has carried a digitally silent track since
+delivery (desktop WEB 9 has the full mix; the edits differ — 21.5s landscape
+vs 14.9s portrait — so the audio can't be transplanted). **Ask (via Diego):
+re-export OURONYX MOBILE 9 with the interview mix.** On arrival: file-swap
+`ouronyx-video-18-mobile.mp4` + flip `hasAudio.mobile` to true.
+
 **Update 2026-08-05 (corrected):** the laptop+phone card Vitor flagged
 ("Beauty Has Power" hero) is the already-wired slot 13 (WEB 4). Done per his
 note: `hasAudio` removed (no speaker) and the track stripped losslessly. If


### PR DESCRIPTION
Vitor confirmed the doctors' interview should have sound on mobile — the MOBILE 9 export has been digitally silent since delivery (CLIENT-ASKS #7 → promoted to a confirmed Diego ask). No code change possible until the re-export lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)