### PR TITLE
feat: hide YSL temporarily (reversible)

### DIFF
--- a/src/__tests__/app/home.test.tsx
+++ b/src/__tests__/app/home.test.tsx
@@ -28,6 +28,12 @@ jest.mock("@/components/home", () => ({
   ),
 }));
 
+const hiddenIds = new Set(
+  projects.filter((p) => p.hidden).map((p) => p.slug),
+);
+const visibleWork = (list: typeof featuredProjects) =>
+  list.filter((p) => !hiddenIds.has(p.id));
+
 describe("Home page", () => {
   it("renders IntroHero with the first featured project's media", () => {
     render(<Home />);
@@ -44,11 +50,19 @@ describe("Home page", () => {
 
     const [, ...workProjects] = featuredProjects;
 
-    workProjects.forEach((project) => {
+    visibleWork(workProjects).forEach((project) => {
       expect(
         screen.getByTestId(`work-gallery-${project.id}`),
       ).toBeInTheDocument();
     });
+    // Hidden projects (YSL, deactivated 2026-08-04) render no tile.
+    workProjects
+      .filter((p) => hiddenIds.has(p.id))
+      .forEach((project) => {
+        expect(
+          screen.queryByTestId(`work-gallery-${project.id}`),
+        ).not.toBeInTheDocument();
+      });
   });
 
   it("renders the intro hero project as both the hero and a single work tile", () => {
@@ -70,7 +84,7 @@ describe("Home page", () => {
     // At least some projects should have gallery media from the projects config
     const [, ...workProjects] = featuredProjects;
     const items = screen.getAllByTestId(/^work-gallery-/);
-    expect(items).toHaveLength(workProjects.length);
+    expect(items).toHaveLength(visibleWork(workProjects).length);
   });
 });
 
@@ -82,7 +96,7 @@ describe("getHomepageMedia logic", () => {
     const [, ...workProjects] = featuredProjects;
 
     // With carousels off (no homepageIndices), no project gets gallery media
-    workProjects.forEach((project) => {
+    visibleWork(workProjects).forEach((project) => {
       const item = screen.getByTestId(`work-gallery-${project.id}`);
       expect(item.getAttribute("data-has-gallery-media")).toBe("false");
     });
@@ -94,7 +108,7 @@ describe("getHomepageMedia logic", () => {
     const [, ...workProjects] = featuredProjects;
 
     // Find a project that has homepageIndices configured
-    workProjects.forEach((project) => {
+    visibleWork(workProjects).forEach((project) => {
       const detail = projects.find((p) => p.slug === project.id);
       if (detail?.carousel?.homepageIndices && detail.carousel.homepageIndices.length > 0) {
         const item = screen.getByTestId(`work-gallery-${project.id}`);
@@ -114,7 +128,7 @@ describe("getHomepageMedia logic", () => {
 
     const [, ...workProjects] = featuredProjects;
 
-    workProjects.forEach((project) => {
+    visibleWork(workProjects).forEach((project) => {
       const item = screen.getByTestId(`work-gallery-${project.id}`);
       const mediaCount = Number(item.getAttribute("data-gallery-media-count"));
       expect(mediaCount).toBe(0);

--- a/src/__tests__/app/work-slug.test.tsx
+++ b/src/__tests__/app/work-slug.test.tsx
@@ -152,7 +152,7 @@ describe("ProjectPage", () => {
     // section to zero height when the hero is an absolutely-positioned video.
     // Mobile-only heroVideos (no desktop file) legitimately keep md:h-auto —
     // their desktop hero is the in-flow static image.
-    const videoProjects = projects.filter((p) => p.heroVideo?.desktop);
+    const videoProjects = projects.filter((p) => p.heroVideo?.desktop && !p.hidden);
     expect(videoProjects.length).toBeGreaterThan(0);
 
     videoProjects.forEach((project) => {
@@ -195,7 +195,7 @@ describe("ProjectPage", () => {
   it("renders hero video when project has heroVideo with mobile source", () => {
     // ouronyx has heroVideo.mobile
     const videoProject = projects.find(
-      (p) => p.heroVideo?.desktop && p.heroVideo.mobile,
+      (p) => p.heroVideo?.desktop && p.heroVideo.mobile && !p.hidden,
     );
 
     if (videoProject) {
@@ -215,7 +215,7 @@ describe("ProjectPage", () => {
   it("renders hero video without mobile source (falls back to desktop)", () => {
     // wao-cosmo has heroVideo but no mobile
     const videoProject = projects.find(
-      (p) => p.heroVideo && !p.heroVideo.mobile,
+      (p) => p.heroVideo && !p.heroVideo.mobile && !p.hidden,
     );
 
     if (videoProject) {

--- a/src/__tests__/app/work.test.tsx
+++ b/src/__tests__/app/work.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import WorkPage from "@/app/work/page";
 import { featuredProjects } from "@/config/site";
+import { projects } from "@/config/projects";
 
 // Mock child components to isolate the page logic
 jest.mock("@/components/home", () => ({
@@ -11,6 +12,12 @@ jest.mock("@/components/home", () => ({
   }) => <div data-testid={`gallery-${project.id}`}>{project.title}</div>,
 }));
 
+const hiddenIds = new Set(
+  projects.filter((p) => p.hidden).map((p) => p.slug),
+);
+const visibleWork = (list: typeof featuredProjects) =>
+  list.filter((p) => !hiddenIds.has(p.id));
+
 describe("Work page", () => {
   it("renders WorkGalleryItem for each project except the first (intro)", () => {
     render(<WorkPage />);
@@ -18,11 +25,19 @@ describe("Work page", () => {
     // First project is the intro hero, excluded from work page
     const [, ...workProjects] = featuredProjects;
 
-    workProjects.forEach((project) => {
+    visibleWork(workProjects).forEach((project) => {
       expect(
         screen.getByTestId(`gallery-${project.id}`),
       ).toBeInTheDocument();
     });
+    // Hidden projects (YSL, deactivated 2026-08-04) render no tile here either.
+    workProjects
+      .filter((p) => hiddenIds.has(p.id))
+      .forEach((project) => {
+        expect(
+          screen.queryByTestId(`gallery-${project.id}`),
+        ).not.toBeInTheDocument();
+      });
   });
 
   it("excludes the intro entry, rendering the intro project only once", () => {
@@ -42,6 +57,6 @@ describe("Work page", () => {
 
     const [, ...workProjects] = featuredProjects;
     const items = screen.getAllByTestId(/^gallery-/);
-    expect(items).toHaveLength(workProjects.length);
+    expect(items).toHaveLength(visibleWork(workProjects).length);
   });
 });

--- a/src/__tests__/config/projects.test.ts
+++ b/src/__tests__/config/projects.test.ts
@@ -49,11 +49,12 @@ describe("getAllProjectSlugs", () => {
     });
   });
 
-  it("should include all 10 named project slugs", () => {
+  it("should include the named project slugs (YSL hidden 2026-08-04)", () => {
     const slugs = getAllProjectSlugs();
     expect(slugs).toContain("ouronyx");
     expect(slugs).toContain("marie-claire-arabia");
-    expect(slugs).toContain("ysl");
+    // YSL is temporarily deactivated — out of slugs/sitemap/params.
+    expect(slugs).not.toContain("ysl");
     expect(slugs).toContain("wao-cosmo");
     expect(slugs).toContain("vivara");
     expect(slugs).toContain("bucherer-summer");
@@ -63,9 +64,9 @@ describe("getAllProjectSlugs", () => {
     expect(slugs).toContain("bride-story");
   });
 
-  it("should return exactly 11 project slugs", () => {
+  it("should return one slug per non-hidden project", () => {
     const slugs = getAllProjectSlugs();
-    expect(slugs.length).toBe(11);
+    expect(slugs.length).toBe(projects.filter((p) => !p.hidden).length);
   });
 
   it("should not contain old gallery slugs", () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,9 @@ export default function Home() {
       {/* Work Gallery Items - Each navigable to its own page.
           Carousel effects are OFF by default. To enable per-project,
           add homepageIndices to the project's carousel config in projects.ts. */}
-      {workProjects.map((project) => {
+      {workProjects
+        .filter((project) => !projectBySlug.get(project.id)?.hidden)
+        .map((project) => {
         const detail = projectBySlug.get(project.id);
         const carouselConfig = detail?.carousel;
         const hasHomepageCarousel = carouselConfig?.homepageIndices && carouselConfig.homepageIndices.length > 0;
@@ -61,7 +63,7 @@ export default function Home() {
             carouselConfig={hasHomepageCarousel ? carouselConfig : undefined}
           />
         );
-      })}
+        })}
 
       {/* Footer after the last tile (client ask, 2026-07-16) — same shared
           footer as the project pages. Desktop-only since review 2026-07-23:

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -17,7 +17,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: ProjectPageProps): Promise<Metadata> {
   const project = getProjectBySlug(params.slug);
 
-  if (!project) return {};
+  if (!project || project.hidden) return {};
 
   return {
     // Bare name only — the root layout template appends "| STUDIO HAUS".
@@ -45,7 +45,8 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<Me
 export default function ProjectPage({ params }: ProjectPageProps) {
   const project = getProjectBySlug(params.slug);
 
-  if (!project) {
+  // Hidden projects 404 like they don't exist (YSL deactivated 2026-08-04).
+  if (!project || project.hidden) {
     notFound();
   }
 

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -24,7 +24,9 @@ export default function WorkPage() {
       {/* Work Gallery Items - Each navigable to its own page, like Home but
           without IntroHero. Tiles play the same hero videos as home since
           2026-08-04 ("página work ainda está só com imagens não vídeos"). */}
-      {projects.map((project) => (
+      {projects
+        .filter((project) => !projectBySlug.get(project.id)?.hidden)
+        .map((project) => (
         <WorkGalleryItem
           key={project.id}
           project={project}

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -128,6 +128,12 @@ export interface ProjectDetail {
   client: string;
   title: string;
   subtitle?: string;
+  /**
+   * Temporarily deactivated: no home/work tile, /work/[slug] 404s, out of
+   * the sitemap and static params. Config (assets, copy, slots) stays
+   * intact — reactivating is deleting this flag.
+   */
+  hidden?: boolean;
 
   // Content
   description: string;
@@ -365,6 +371,9 @@ export const projects: ProjectDetail[] = [
   {
     id: "ysl",
     slug: "ysl",
+    // Deactivated per Vitor 2026-08-04 ("deixa o YSL por enquanto
+    // desativado... vamos ativar mais pra frente") — delete to reactivate.
+    hidden: true,
     client: "YSL",
     title: "YSL Beauty - The Golden Celebration",
     subtitle: "Creative Direction",
@@ -2228,5 +2237,6 @@ export function getProjectBySlug(slug: string): ProjectDetail | undefined {
  * Get all project slugs for static generation
  */
 export function getAllProjectSlugs(): string[] {
-  return projects.map((project) => project.slug);
+  // Hidden projects stay out of static params and the sitemap.
+  return projects.filter((p) => !p.hidden).map((project) => project.slug);
 }


### PR DESCRIPTION
Vitor 2026-08-04: "deixa o YSL por enquanto desativado… vamos ativar mais pra frente."

New `ProjectDetail.hidden` flag, honored everywhere the project surfaces: home tiles, /work tiles, `/work/[slug]` (404 + empty metadata), `generateStaticParams` and the sitemap (both via the central `getAllProjectSlugs`). All YSL config, copy and assets stay intact — **reactivation = deleting one flag line**.

Tests updated to the new behavior (visible-set helpers + explicit hidden-tile assertions). Verified on dev: 0 YSL references on home/work, `/work/ysl` → 404, 0 sitemap entries. Gate: tsc ✓ jest 287/287 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)