### PR TITLE
docs: rebuild missing changelog entries

### DIFF
--- a/docs/CHANGELOG-2026-07-28.md
+++ b/docs/CHANGELOG-2026-07-28.md
@@ -51,3 +51,22 @@ do review para o Vitor conferir item a item. PRs: #83 (copy), #86 (tipografia),
 
 - ✅ **Showreel mobile no ar** — o edit vertical de 04/08 toca no topo da home no celular. ⚠️ O arquivo veio comprimido pelo WhatsApp (480p, meio suave em tela retina) e sem áudio — quando o Vitor mandar o export original **como documento**, é só trocar o arquivo.
 - ✅ **Site muito mais rápido** (PR #93, medido): home LCP 3,4s → 0,09s; nada de vídeo invisível baixando na chegada; revisita das páginas quase instantânea (cache); e em desktop a página inteira se pré-carrega em paralelo — rolou, tocou.
+
+## 2026-08-04 (noite)
+
+- ✅ **Página WORK com vídeos** — os mesmos vídeos de capa da home tocam nos tiles do /work.
+- ✅ **Contato** — New Business: "hubs in London, **Dubai** and São Paulo"; For Talent: removida a frase "We operate hybrid in remote…".
+
+## 2026-08-05
+
+- ✅ **Showreel desktop atualizado** — o edit novo de 18s (1080p, enviado como documento ✓) substitui o corte antigo; desktop e mobile agora tocam o mesmo edit.
+- ✅ **Home 100% sem som** — nenhum asset da home tem botão de áudio (pedido de 05/08).
+- ✅ **Ouronyx** — card do site (laptop + celular) sem botão de som; e o vídeo dos médicos ganhou áudio no mobile (o Diego tinha atualizado o arquivo no Drive — baixado e trocado).
+- ✅ **YSL desativado temporariamente** — sem tile na home/WORK, página 404, fora do sitemap. Reativar é apagar uma linha ("vamos ativar mais pra frente").
+- ✅ **Harrods — banner desktop com o áudio certo** — mesmo edit de 15s, re-export com a mixagem corrigida.
+- ✅ **BFJ — imagem da sacada nítida** — a foto original (BUC_WEB_11) substituiu o frame de vídeo lavado no slot 11 (desktop).
+
+## Ainda aberto (não entrou neste deploy)
+
+- ⏳ **Diego**: re-exports em alta dos cards de UI do Ouronyx (#5) + versão ≥1440w e crop mobile da sacada BFJ (#6) + re-exports nos bitrates da tabelinha (velocidade em conexão lenta).
+- ⏳ **Vitor**: export original do showreel mobile **como documento** (o atual veio comprimido do WhatsApp) · ⚠️ **renovar o domínio até 02/09** · trocar a senha do GoDaddy · pode cancelar o Cargo.


### PR DESCRIPTION
The 'Ainda aberto' marker was dropped in the #94 rebase resolution, so changelog inserts from PRs #95–#103 silently no-opped. This restores the 2026-08-04(noite)/2026-08-05 sections and the open-items list. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)