### PR TITLE
feat: email links open mail app + copy fallback

### DIFF
--- a/docs/CHANGELOG-2026-07-28.md
+++ b/docs/CHANGELOG-2026-07-28.md
@@ -66,6 +66,8 @@ do review para o Vitor conferir item a item. PRs: #83 (copy), #86 (tipografia),
 - ✅ **Harrods — banner desktop com o áudio certo** — mesmo edit de 15s, re-export com a mixagem corrigida.
 - ✅ **BFJ — imagem da sacada nítida** — a foto original (BUC_WEB_11) substituiu o frame de vídeo lavado no slot 11, **desktop e mobile**.
 
+- ✅ **Email clicável à prova de falha** — clicar no email (rodapé, contato, menu mobile) abre o app de email nativo E copia o endereço com um "copied ✓" discreto — ninguém mais fica sem resposta ao clicar.
+
 ## Ainda aberto (não entrou neste deploy)
 
 - ⏳ **Diego**: re-exports em alta dos cards de UI do Ouronyx (#5) + versão ≥1440w e crop mobile da sacada BFJ (#6) + re-exports nos bitrates da tabelinha (velocidade em conexão lenta).

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { siteConfig } from "@/config/site";
+import { EmailLink } from "@/components/ui/EmailLink";
 
 export const metadata: Metadata = {
   title: "Contact",
@@ -23,12 +24,10 @@ export default function ContactPage() {
           </div>
           <div className="flex-1">
             <p className="text-[15px] leading-[1.53em] md:text-[18px] md:leading-[1.55em]">
-              <a
-                href={`mailto:${siteConfig.email}`}
+<EmailLink
+                email={siteConfig.email}
                 className="hover:opacity-50 transition-opacity"
-              >
-                {siteConfig.email}
-              </a>
+              />
             </p>
           </div>
         </div>
@@ -76,12 +75,10 @@ export default function ContactPage() {
               {/* "Reach out via…" starts its own line (review 2026-07-23). */}
               <br />
               Reach out via{" "}
-              <a
-                href={`mailto:${siteConfig.email}`}
+<EmailLink
+                email={siteConfig.email}
                 className="hover:opacity-50 transition-opacity"
-              >
-                {siteConfig.email}
-              </a>{" "}
+              />{" "}
               at any time.
             </p>
           </div>

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { siteConfig } from "@/config/site";
+import { EmailLink } from "@/components/ui/EmailLink";
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -67,13 +68,7 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
         `}
         style={{ transitionDelay: isOpen ? "200ms" : "0ms" }}
       >
-        <a
-          href={`mailto:${siteConfig.email}`}
-          tabIndex={isOpen ? 0 : -1}
-          className="text-[15px] leading-[1.21em] transition-opacity duration-250 hover:opacity-50"
-        >
-          {siteConfig.email}
-        </a>
+        <EmailLink email={siteConfig.email} tabIndex={isOpen ? 0 : -1} className="text-[15px] leading-[1.21em] transition-opacity duration-250 hover:opacity-50" />
       </div>
 
       {/* Social Links */}

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { siteConfig } from "@/config/site";
+import { EmailLink } from "@/components/ui/EmailLink";
 
 /**
  * Site footer — hairline divider, contact email left, social links right
@@ -16,14 +17,13 @@ export function SiteFooter() {
       <div className="px-[21px] md:px-[41px] md:pr-[44px]">
         {/* Mobile: stacked vertically. Desktop: email left, social right */}
         <div className="flex flex-col md:flex-row md:justify-between pt-[71px] md:pt-[60px] pb-[60px] md:pb-[40px]">
-          {/* Contact Email — plain <a> for native mailto: handling */}
+          {/* Contact Email — mailto opens the native mail app; click also
+              copies the address (fallback for no-mail-app machines). */}
           <div>
-            <a
-              href={`mailto:${siteConfig.email}`}
+            <EmailLink
+              email={siteConfig.email}
               className="text-[15px] leading-[1.21em] hover:opacity-50 transition-opacity"
-            >
-              {siteConfig.email}
-            </a>
+            />
           </div>
 
           {/* Social Links - vertical on mobile, horizontal on desktop */}

--- a/src/components/ui/EmailLink.tsx
+++ b/src/components/ui/EmailLink.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface EmailLinkProps {
+  email: string;
+  className?: string;
+  /** Forwarded to the anchor (MobileMenu manages tab order when closed). */
+  tabIndex?: number;
+}
+
+/**
+ * Contact email link: `mailto:` opens the visitor's native mail app (the
+ * strongest instruction the web has) — and the click ALSO copies the
+ * address with a discreet "copied ✓", so machines with no mail app
+ * configured (where mailto silently no-ops, e.g. gmail-in-browser setups)
+ * still leave with the address in hand.
+ */
+export function EmailLink({ email, className, tabIndex }: EmailLinkProps) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const handleClick = () => {
+    // No preventDefault: the mailto proceeds natively; the copy is a
+    // non-blocking safety net.
+    try {
+      void navigator.clipboard?.writeText(email);
+    } catch {
+      /* clipboard unavailable (http/permissions) — mailto still runs */
+    }
+    setCopied(true);
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <span className="relative inline-block">
+      <a
+        href={`mailto:${email}`}
+        onClick={handleClick}
+        className={className}
+        tabIndex={tabIndex}
+      >
+        {email}
+      </a>
+      <span
+        aria-live="polite"
+        className={`pointer-events-none absolute left-0 -top-[20px] text-[11px] uppercase tracking-[0.08em] transition-opacity duration-300 ${
+          copied ? "opacity-50" : "opacity-0"
+        }`}
+      >
+        {copied ? "copied ✓" : ""}
+      </span>
+    </span>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
+export { EmailLink } from "./EmailLink";
 export { GalleryGrid } from "./GalleryGrid";
 export { HeroVideo } from "./HeroVideo";
 export { Logo } from "./Logo";


### PR DESCRIPTION
User-reported: clicking the footer email "does nothing" — verified the mailto anchor is healthy (correct href, nothing overlapping, hit-test clean); the silent no-op is the OS behavior on machines with no default mail app.

Fix: new `EmailLink` client component used in the footer, contact page (×2) and mobile menu — `mailto:` proceeds natively (opens Mail/Outlook/iPhone Mail where configured) and the click also copies the address with a discreet 2s "copied ✓" (aria-live). `tabIndex` forwarded so MobileMenu's closed-state tab-order management keeps working. Deep imports (not the ui barrel) to stay clear of test barrel mocks.

Verified on dev: click shows the toast and fades; href intact. Gate: tsc ✓ jest 287/287 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)